### PR TITLE
Don't use VMware resource pools for organization

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -158,7 +158,7 @@ module Vmpooler
     end
 
     # Clone a VM
-    def clone_vm template, pool, folder, datastore
+    def clone_vm template, folder, datastore
       Thread.new {
         vm = {}
 
@@ -198,7 +198,6 @@ module Vmpooler
         # Put the VM in the specified folder and resource pool
         relocateSpec = RbVmomi::VIM.VirtualMachineRelocateSpec(
           :datastore    => $vsphere[vm['template']].find_datastore(datastore),
-          :pool         => $vsphere[vm['template']].find_pool(pool),
           :diskMoveType => :moveChildMostDiskBacking
         )
 
@@ -279,9 +278,9 @@ module Vmpooler
           # INVENTORY
           inventory = {}
           begin
-            base = $vsphere[pool['name']].find_pool(pool['pool'])
+            base = $vsphere[pool['name']].find_folder(pool['folder'])
 
-            base.vm.each do |vm|
+            base.childEntity.each do |vm|
               if (
                 (! $redis.sismember('vmpooler__running__'+pool['name'], vm['name'])) and
                 (! $redis.sismember('vmpooler__ready__'+pool['name'], vm['name'])) and
@@ -407,7 +406,6 @@ module Vmpooler
 
                   clone_vm(
                     pool['template'],
-                    pool['pool'],
                     pool['folder'],
                     pool['datastore']
                   )

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -123,10 +123,6 @@
 #     The vSphere 'folder' destination for spawned clones.
 #     (required)
 #
-#   - pool
-#     The vSphere 'resource pool' destination for spawned clones.
-#     (required)
-#
 #   - datastore
 #     The vSphere 'datastore' destination for spawned clones.
 #     (required)
@@ -149,7 +145,6 @@
   - name: 'debian-7-i386'
     template: 'Templates/debian-7-i386'
     folder: 'Pooled VMs/debian-7-i386'
-    pool: 'Pooled VMs/debian-7-i386'
     datastore: 'vmstorage'
     size: 5
     timeout: 15
@@ -157,7 +152,6 @@
   - name: 'debian-7-x86_64'
     template: 'Templates/debian-7-x86_64'
     folder: 'Pooled VMs/debian-7-x86_64'
-    pool: 'Pooled VMs/debian-7-x86_64'
     datastore: 'vmstorage'
     size: 5
     timeout: 15


### PR DESCRIPTION
This commit removes support for VMware 'resource pool' functionality
entirely, as VMware installations without the DRS feature enabled are
unable to configure or use resource pools.

Also, resource pools should have never been used for organization;
that's what folders are for.
