### PR TITLE
Don't deploy VMs to not-good hypervisors

### DIFF
--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -65,8 +65,10 @@ module Vmpooler
       datacenter.hostFolder.children.each do |folder|
         next unless folder.name == cluster
         folder.host.each do |host|
-          hosts[host.name] = host
-          hosts_sort[host.name] = host.vm.length
+          if host.overallStatus == 'green'
+            hosts[host.name] = host
+            hosts_sort[host.name] = host.vm.length
+          end
         end
       end
 


### PR DESCRIPTION
This implements a check to ensure that the VMware host being deployed to
is in a sane ('green') state.
