### PR TITLE
Ensure hosts aren't in 'maintenance mode' when cloning

### DIFF
--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -65,7 +65,10 @@ module Vmpooler
       datacenter.hostFolder.children.each do |folder|
         next unless folder.name == cluster
         folder.host.each do |host|
-          if host.overallStatus == 'green'
+          if (
+            (host.overallStatus == 'green') and
+            (! host.runtime.inMaintenanceMode)
+          )
             hosts[host.name] = host
             hosts_sort[host.name] = host.vm.length
           end


### PR DESCRIPTION
host.overallStatus reports 'green' even when a host is in 'maintenance mode', requiring an additional check.
