### PR TITLE
(QENG-1873) Match status endpoint

### DIFF
--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -268,10 +268,10 @@ module Vmpooler
             result[:clone][:total] += me[:clone][:total]
             total_clones_per_day.push(me[:clone][:total])
 
-            clone_times = $redis.hvals('vmpooler__clone__' + date.to_s)
+            clone_times = $redis.hvals('vmpooler__clone__' + date.to_s).map(&:to_f)
 
             unless clone_times.nil? or clone_times.empty?
-              clone_time = clone_times.map(&:to_f).reduce(:+).to_f
+              clone_time = clone_times.reduce(:+).to_f
               total_clone_time += clone_time
 
               me[:clone][:min], me[:clone][:max] = clone_times.minmax
@@ -293,8 +293,8 @@ module Vmpooler
 
           # again, calc clone_average if we had clones.
           if result[:clone][:total] > 0
-            result[:clone][:timings][:average] = total_clone_time / result[:clone][:total]
-            result[:clone][:timings][:min], result[:clone][:timings][:max] = min_max_clone_times.minmax
+            result[:clone][:duration][:average] = total_clone_time / result[:clone][:total]
+            result[:clone][:duration][:min], result[:clone][:duration][:max] = min_max_clone_times.minmax
             result[:clone][:min], result[:clone][:max] = total_clones_per_day.minmax
             result[:clone][:average] = mean(total_clones_per_day)
           end

--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -309,12 +309,15 @@ module Vmpooler
 
           # again, calc clone_average if we had clones.
           unless total_clones_per_day.nil? or total_clones_per_day.length == 0
+            # totals
+            result[:clone][:count][:total] = total_clones_per_day.reduce(:+).to_i
+            result[:clone][:duration][:total] = total_clone_dur_day.reduce(:+).to_f
+
+            # averages and other things.
             result[:clone][:duration][:average] = result[:clone][:duration][:total] / result[:clone][:count][:total]
             result[:clone][:duration][:min], result[:clone][:duration][:max] = min_max_clone_times.minmax
-            result[:clone][:duration][:total] = total_clone_dur_day.reduce(:+).to_f
             result[:clone][:count][:min], result[:clone][:count][:max] = total_clones_per_day.minmax
             result[:clone][:count][:average] = mean(total_clones_per_day)
-            result[:clone][:count][:total] = total_clones_per_day.reduce(:+).to_i
           end
 
           content_type :json

--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -296,7 +296,7 @@ module Vmpooler
               # if clone_total > 0, calculate clone_average.
               # this prevents divide by 0 problems.
               if me[:clone][:count][:total] > 0
-                me[:clone][:duration][:average] = clone_time / me[:clone][:duration][:total]
+                me[:clone][:duration][:average] = mean(clone_times)
               else
                 me[:clone][:duration][:average] = 0
               end


### PR DESCRIPTION
These changes are to match the status endpoints JSON payload. This also
introduces both clone timings and information on total clones. The field
"day" is renamed to "date" to accomodate when from/to will include
times.