### PR TITLE
(maint) Fix Divide by 0 Bug

### DIFF
--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -345,8 +345,14 @@ module Vmpooler
             result[:clone][:duration][:total] = total_clone_dur_day.reduce(:+).to_f
 
             # averages and other things.
-            result[:clone][:duration][:average] = result[:clone][:duration][:total] / result[:clone][:count][:total]
-            result[:clone][:duration][:min], result[:clone][:duration][:max] = min_max_clone_times.minmax
+            if result[:clone][:count][:total] != 0
+              result[:clone][:duration][:average] = result[:clone][:duration][:total] / result[:clone][:count][:total]
+            end
+
+            if min_max_clone_times.length > 0
+              result[:clone][:duration][:min], result[:clone][:duration][:max] = min_max_clone_times.minmax
+            end
+
             result[:clone][:count][:min], result[:clone][:count][:max] = total_clones_per_day.minmax
             result[:clone][:count][:average] = mean(total_clones_per_day)
           end


### PR DESCRIPTION
When a redis key does not exist for a single-day summary, the
total_clones_per_day array has a length of 1 with a single value of 0.
This gets past an initial check of array length, but is then reduced to
a value of 0, which is then used as the denominator of an average
calculation. The result of this calculation is NaN and later causes
JSON.pretty_generate to raise an exception.

This also includes a check on the min_max_clone_times array, because
[].minmax returns [nil, nil].