### PR TITLE
(QENG-2057) Historic Redis VM metadata

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -11,7 +11,7 @@ module Vmpooler
   require 'timeout'
   require 'yaml'
 
-  %w( api graphite logger pool_manager vsphere_helper ).each do |lib|
+  %w( api graphite janitor logger pool_manager vsphere_helper ).each do |lib|
     begin
       require "vmpooler/#{lib}"
     rescue LoadError

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -340,6 +340,7 @@ module Vmpooler
             unless vm.nil?
               $redis.sadd('vmpooler__running__' + key, vm)
               $redis.hset('vmpooler__active__' + key, vm, Time.now)
+              $redis.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
 
               result[key] ||= {}
 
@@ -403,6 +404,7 @@ module Vmpooler
           unless vm.nil?
             $redis.sadd('vmpooler__running__' + template, vm)
             $redis.hset('vmpooler__active__' + template, vm, Time.now)
+            $redis.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
 
             result[template] ||= {}
 

--- a/lib/vmpooler/janitor.rb
+++ b/lib/vmpooler/janitor.rb
@@ -1,0 +1,39 @@
+module Vmpooler
+  class Janitor
+    def initialize
+      # Load the configuration file
+      config_file = File.expand_path('vmpooler.yaml')
+      $config = YAML.load_file(config_file)
+
+      # Set some defaults
+      $config[:redis]             ||= {}
+      $config[:redis]['server']   ||= 'localhost'
+      $config[:redis]['data_ttl'] ||= 168
+
+      # Load logger library
+      $logger = Vmpooler::Logger.new $config[:config]['logfile']
+
+      # Connect to Redis
+      $redis = Redis.new(host: $config[:redis]['server'])
+    end
+
+    def execute!
+
+      loop do
+        $redis.keys('vmpooler__vm__*').each do |key|
+          data = $redis.hgetall(key);
+
+          if data['destroy']
+            lifetime = (Time.now - Time.parse(data['destroy'])) / 60 / 60
+
+            if lifetime > $config[:redis]['data_ttl']
+              $redis.del(key)
+            end
+          end
+        end
+
+        sleep(600)
+      end
+    end
+  end
+end

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -11,8 +11,8 @@ module Vmpooler
       $config[:config]['task_limit']   ||= 10
       $config[:config]['vm_checktime'] ||= 15
       $config[:config]['vm_lifetime']  ||= 24
-      $config[:redis] ||= {}
-      $config[:redis]['server'] ||= 'localhost'
+      $config[:redis]             ||= {}
+      $config[:redis]['server']   ||= 'localhost'
 
       # Load logger library
       $logger = Vmpooler::Logger.new $config[:config]['logfile']

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -256,7 +256,7 @@ module Vmpooler
       Thread.new do
         $redis.srem('vmpooler__completed__' + pool, vm)
         $redis.hdel('vmpooler__active__' + pool, vm)
-        $redis.del('vmpooler__vm__' + vm)
+        $redis.hset('vmpooler__vm__' + vm, 'destroy', Time.now)
 
         host = $vsphere[pool].find_vm(vm) ||
                $vsphere[pool].find_vm_heavy(vm)[vm]

--- a/vmpooler
+++ b/vmpooler
@@ -6,6 +6,7 @@ require 'rubygems' unless defined?(Gem)
 require 'lib/vmpooler'
 
 Thread.new { Vmpooler::API.new.execute! }
+Thread.new { Vmpooler::Janitor.new.execute! }
 Thread.new { Vmpooler::PoolManager.new.execute! }
 
 loop do

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -43,6 +43,10 @@
 #   - password
 #     The password used to authenticate Redis.
 #     (optional)
+#
+#   - data_ttl
+#     How long (in hours) to retain metadata in Redis after VM destruction.
+#     (optional; default: '168')
 
 # Example:
 


### PR DESCRIPTION
- Store VM 'checkout' and 'destroy' timestamps in Redis VM metadata object
- Do not destroy said object upon VM destruction
- Implement a Vmpooler::Janitor worker thread which compares the 'destroy' timestamp with a configurable redis['data_ttl'] option; destroy metadata object if TTL is exceeded