### PR TITLE
Default 'created_by' & 'project' tags as 'unknown'

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -189,6 +189,10 @@ module Vmpooler
         $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone', Time.now)
         $redis.hset('vmpooler__vm__' + vm['hostname'], 'template', vm['template'])
 
+        # Set some default tags
+        $redis.hset('vmpooler__vm__' + vm['hostname'], 'tag:created_by', 'unknown')
+        $redis.hset('vmpooler__vm__' + vm['hostname'], 'tag:project', 'unknown')
+
         # Annotate with creation time, origin template, etc.
         configSpec = RbVmomi::VIM.VirtualMachineConfigSpec(
           annotation: JSON.pretty_generate(


### PR DESCRIPTION
This will allow easier tracking of untagged VMs.