### PR TITLE
(QENG-1906) Refactor initialize to allow config passing

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -18,4 +18,47 @@ module Vmpooler
       require File.expand_path(File.join(File.dirname(__FILE__), 'vmpooler', lib))
     end
   end
+
+  def self.config(filepath='vmpooler.yaml')
+    # Load the configuration file
+    config_file = File.expand_path(filepath)
+    parsed_config = YAML.load_file(config_file)
+
+    # Set some defaults
+    parsed_config[:redis]             ||= {}
+    parsed_config[:redis]['server']   ||= 'localhost'
+    parsed_config[:redis]['data_ttl'] ||= 168
+
+    parsed_config[:config]['task_limit']   ||= 10
+    parsed_config[:config]['vm_checktime'] ||= 15
+    parsed_config[:config]['vm_lifetime']  ||= 24
+
+    if parsed_config[:graphite]['server']
+      parsed_config[:graphite]['prefix'] ||= 'vmpooler'
+    end
+
+    parsed_config[:uptime] = Time.now
+
+    parsed_config
+  end
+
+  def self.new_redis(host='localhost')
+    Redis.new(host: host)
+  end
+
+  def self.new_logger(logfile)
+    Vmpooler::Logger.new logfile
+  end
+
+  def self.new_graphite(server)
+    if server.nil? or server.empty? or server.length == 0
+      nil
+    else
+      Vmpooler::Graphite.new server
+    end
+  end
+
+  def self.pools(conf)
+    conf[:pools]
+  end
 end

--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -1,24 +1,7 @@
 module Vmpooler
   class API < Sinatra::Base
     def initialize
-      # Load the configuration file
-      config_file = File.expand_path('vmpooler.yaml')
-      $config = YAML.load_file(config_file)
-
-      $config[:uptime] = Time.now
-
-      # Set some defaults
-      $config[:redis] ||= {}
-      $config[:redis]['server'] ||= 'localhost'
-
-      if $config[:graphite]['server']
-        $config[:graphite]['prefix'] ||= 'vmpooler'
-      end
-
-      # Connect to Redis
-      $redis = Redis.new(host: $config[:redis]['server'])
-
-      super()
+      super
     end
 
     set :environment, :production
@@ -51,8 +34,14 @@ module Vmpooler
     use Vmpooler::API::Reroute
     use Vmpooler::API::V1
 
-    Thread.new do
-      run!
+    def configure(config, redis, environment = :production)
+      self.settings.set :config, config
+      self.settings.set :redis, redis
+      self.settings.set :environment, environment
+    end
+
+    def execute!
+      self.settings.run!
     end
   end
 end

--- a/lib/vmpooler/api/dashboard.rb
+++ b/lib/vmpooler/api/dashboard.rb
@@ -6,19 +6,19 @@ module Vmpooler
 
       result = {}
 
-      $config[:pools].each do |pool|
+      Vmpooler::API.settings.config[:pools].each do |pool|
         result[pool['name']] ||= {}
         result[pool['name']]['size'] = pool['size']
         result[pool['name']]['ready'] = $redis.scard('vmpooler__ready__' + pool['name'])
       end
 
       if params[:history]
-        if $config[:graphite]['server']
+        if Vmpooler::API.settings.config[:graphite]['server']
           history ||= {}
 
           begin
             buffer = open(
-              'http://' + $config[:graphite]['server'] + '/render?target=' + $config[:graphite]['prefix'] + '.ready.*&from=-1hour&format=json'
+              'http://' + Vmpooler::API.settings.config[:graphite]['server'] + '/render?target=' + Vmpooler::API.settings.config[:graphite]['prefix'] + '.ready.*&from=-1hour&format=json'
             ).read
             history = JSON.parse(buffer)
 
@@ -46,9 +46,9 @@ module Vmpooler
           rescue
           end
         else
-          $config[:pools].each do |pool|
+          Vmpooler::API.settings.config[:pools].each do |pool|
             result[pool['name']] ||= {}
-            result[pool['name']]['history'] = [$redis.scard('vmpooler__ready__' + pool['name'])]
+            result[pool['name']]['history'] = [Vmpooler::API.settings.redis.scard('vmpooler__ready__' + pool['name'])]
           end
         end
       end
@@ -61,8 +61,8 @@ module Vmpooler
 
       result = {}
 
-      $config[:pools].each do |pool|
-        running = $redis.scard('vmpooler__running__' + pool['name'])
+      Vmpooler::API.settings.config[:pools].each do |pool|
+        running = Vmpooler::API.settings.redis.scard('vmpooler__running__' + pool['name'])
         pool['major'] = Regexp.last_match[1] if pool['name'] =~ /^(\w+)\-/
 
         result[pool['major']] ||= {}
@@ -71,10 +71,10 @@ module Vmpooler
       end
 
       if params[:history]
-        if $config[:graphite]['server']
+        if Vmpooler::API.settings.config[:graphite]['server']
           begin
             buffer = open(
-              'http://' + $config[:graphite]['server'] + '/render?target=' + $config[:graphite]['prefix'] + '.running.*&from=-1hour&format=json'
+              'http://' + Vmpooler::API.settings.config[:graphite]['server'] + '/render?target=' + Vmpooler::API.settings.config[:graphite]['prefix'] + '.running.*&from=-1hour&format=json'
             ).read
             JSON.parse(buffer).each do |pool|
               if pool['target'] =~ /.*\.(.*)$/

--- a/lib/vmpooler/janitor.rb
+++ b/lib/vmpooler/janitor.rb
@@ -1,32 +1,26 @@
 module Vmpooler
   class Janitor
-    def initialize
-      # Load the configuration file
-      config_file = File.expand_path('vmpooler.yaml')
-      $config = YAML.load_file(config_file)
-
-      # Set some defaults
-      $config[:redis]             ||= {}
-      $config[:redis]['server']   ||= 'localhost'
-      $config[:redis]['data_ttl'] ||= 168
-
+    def initialize(logger, redis, data_ttl)
       # Load logger library
-      $logger = Vmpooler::Logger.new $config[:config]['logfile']
+      $logger = logger
 
       # Connect to Redis
-      $redis = Redis.new(host: $config[:redis]['server'])
+      $redis = redis
+
+      # TTL
+      $data_ttl = data_ttl
     end
 
     def execute!
 
       loop do
         $redis.keys('vmpooler__vm__*').each do |key|
-          data = $redis.hgetall(key);
+          data = $redis.hgetall(key)
 
           if data['destroy']
             lifetime = (Time.now - Time.parse(data['destroy'])) / 60 / 60
 
-            if lifetime > $config[:redis]['data_ttl']
+            if lifetime > $data_ttl
               $redis.del(key)
             end
           end

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -1,30 +1,19 @@
 module Vmpooler
   class PoolManager
-    def initialize
-      # Load the configuration file
-      config_file = File.expand_path('vmpooler.yaml')
-      $config = YAML.load_file(config_file)
+    def initialize(config, pools, logger, redis, graphite=nil)
+      $config = config
 
-      $pools   = $config[:pools]
-
-      # Set some defaults
-      $config[:config]['task_limit']   ||= 10
-      $config[:config]['vm_checktime'] ||= 15
-      $config[:config]['vm_lifetime']  ||= 24
-      $config[:redis]             ||= {}
-      $config[:redis]['server']   ||= 'localhost'
+      $pools   = pools
 
       # Load logger library
-      $logger = Vmpooler::Logger.new $config[:config]['logfile']
+      $logger = logger
 
-      # Load Graphite helper library (if configured)
-      if defined? $config[:graphite]['server']
-        $config[:graphite]['prefix'] ||= 'vmpooler'
-        $graphite = Vmpooler::Graphite.new $config[:graphite]['server']
+      unless graphite.nil?
+        $graphite = graphite
       end
 
       # Connect to Redis
-      $redis = Redis.new(host: $config[:redis]['server'])
+      $redis = redis
 
       # vSphere object
       $vsphere = {}

--- a/vmpooler
+++ b/vmpooler
@@ -5,10 +5,27 @@ $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'rubygems' unless defined?(Gem)
 require 'lib/vmpooler'
 
-Thread.new { Vmpooler::API.new.execute! }
-Thread.new { Vmpooler::Janitor.new.execute! }
-Thread.new { Vmpooler::PoolManager.new.execute! }
+config = Vmpooler.config
+redis_host = config[:redis]['server']
+redis_ttl = config[:redis]['data_ttl']
+logger_file = config[:config]['logfile']
+graphite = defined? config[:graphite]['server'] ? config[:graphite]['server'] : nil
 
-loop do
-  sleep(10)
-end
+api = Thread.new {
+        thr = Vmpooler::API.new
+        thr.helpers.configure(config, Vmpooler.new_redis(redis_host))
+        thr.helpers.execute!
+      }
+janitor = Thread.new {
+            Vmpooler::Janitor.new(Vmpooler.new_logger(logger_file), Vmpooler.new_redis(redis_host), redis_ttl).execute!
+          }
+manager = Thread.new {
+            Vmpooler::PoolManager.new(config,
+                                      config[:pools],
+                                      Vmpooler.new_logger(logger_file),
+                                      Vmpooler.new_redis(redis_host),
+                                      Vmpooler.new_graphite(graphite)).execute!
+          }
+
+[api, janitor, manager].each { |t| t.join }
+


### PR DESCRIPTION
Prior to this commit, several pieces of vmpooler performed configuration
and initialization steps within 'initialize'. This made it difficult to
pass in mock objects for testing purposes.

This commit performs a single configuration and passes the results to
the various pieces of vmpooler.