### PR TITLE
running-to-lifetime comparison should be 'greater than or equal to'

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -399,7 +399,7 @@ module Vmpooler
 
               if
                 (lifetime.to_i > 0) &&
-                (running.to_i > lifetime.to_i)
+                (running.to_i >= lifetime.to_i)
 
                 $redis.smove('vmpooler__running__' + pool['name'], 'vmpooler__completed__' + pool['name'], vm)
 


### PR DESCRIPTION
Prior to this commit, both `lifetime` and `running` were converted to `int`s and compared, causing the VM to be destroyed an hour AFTER the `vm_lifetime` config setting.