### PR TITLE
Ensure 'lifetime' val returned by GET /vm/:hostname is an int

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -452,7 +452,7 @@ module Vmpooler
         result[params[:hostname]] = {}
 
         result[params[:hostname]]['template'] = rdata['template']
-        result[params[:hostname]]['lifetime'] = rdata['lifetime'] || Vmpooler::API.settings.config[:config]['vm_lifetime']
+        result[params[:hostname]]['lifetime'] = (rdata['lifetime'] || Vmpooler::API.settings.config[:config]['vm_lifetime']).to_i
 
         if rdata['destroy']
           result[params[:hostname]]['running'] = ((Time.parse(rdata['destroy']) - Time.parse(rdata['checkout'])) / 60 / 60).round(2)


### PR DESCRIPTION
Prior to this PR, if a VM's `lifetime` was changed via `POST /vm/:hostname`, the value pulled from Redis is evaluated as a string.  This forced it to return an integer in the endpoint output.