### PR TITLE
Redirect / to /dashboard

### DIFF
--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -17,11 +17,19 @@ module Vmpooler
     end
 
     get '/' do
-      erb :dashboard, locals: {
-        site_name: $config[:config]['site_name'] || '<b>vmpooler</b>'
-      }
+      redirect to('/dashboard/')
     end
 
+    # Load dashboard components
+    begin
+      require "dashboard"
+    rescue LoadError
+      require File.expand_path(File.join(File.dirname(__FILE__), 'dashboard'))
+    end
+
+    use Vmpooler::Dashboard
+
+    # Load API components
     %w( dashboard reroute v1 ).each do |lib|
       begin
         require "api/#{lib}"

--- a/lib/vmpooler/dashboard.rb
+++ b/lib/vmpooler/dashboard.rb
@@ -1,0 +1,9 @@
+module Vmpooler
+  class Dashboard < Sinatra::Base
+    get '/dashboard/?' do
+      erb :dashboard, locals: {
+        site_name: $config[:config]['site_name'] || '<b>vmpooler</b>'
+      }
+    end
+  end
+end

--- a/spec/vmpooler/api_spec.rb
+++ b/spec/vmpooler/api_spec.rb
@@ -11,13 +11,20 @@ describe Vmpooler::API do
   describe 'Dashboard' do
 
     context '/' do
+      before { get '/' }
+
+      it { expect(last_response.status).to eq(302) }
+      it { expect(last_response.location).to eq('http://example.org/dashboard/') }
+    end
+
+    context '/dashboard/' do
       let(:config) { {
           config: {'site_name' => 'test pooler'}
       } }
 
       before do
         $config = config
-        get '/'
+        get '/dashboard/'
       end
 
       it { expect(last_response).to be_ok }


### PR DESCRIPTION
This PR also introduces a new `Vmpooler::Dashboard` library which contains all of the Sinatra routes to dashboards (currently just the one).