### PR TITLE
(maint) Check for 'checkout' key if calculating 'running' time

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -426,7 +426,7 @@ module Vmpooler
 
         if rdata['destroy']
           result[params[:hostname]]['running'] = ((Time.parse(rdata['destroy']) - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
-        else
+        elsif rdata['checkout']
           result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
         end
 


### PR DESCRIPTION
Previous to this patch Sinatra would return an ugly error if querying an unused VM.