### PR TITLE
Display VM state in GET /vm/:hostname route

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,8 @@ $ curl --url vmpooler.company.com/vm/pxpmtoonx7fiqg6
   "pxpmtoonx7fiqg6": {
     "template": "centos-6-x86_64",
     "lifetime": 12,
-    "running": 3,
+    "running": 3.1,
+    "state": "running",
     "domain": "company.com"
   }
 }

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -426,8 +426,14 @@ module Vmpooler
 
         if rdata['destroy']
           result[params[:hostname]]['running'] = ((Time.parse(rdata['destroy']) - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
+          result[params[:hostname]]['state'] = 'destroyed'
         elsif rdata['checkout']
           result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
+          result[params[:hostname]]['state'] = 'running'
+        elsif rdata['check']
+          result[params[:hostname]]['state'] = 'ready'
+        else
+          result[params[:hostname]]['state'] = 'pending'
         end
 
         rdata.keys.each do |key|

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -426,7 +426,7 @@ module Vmpooler
 
         if rdata['destroy']
           result[params[:hostname]]['running'] = ((Time.parse(rdata['destroy']) - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
-        else
+        elsif rdata['checkout']
           result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
         end
 


### PR DESCRIPTION
eg. 'pending', 'ready', 'running', or 'destroyed'.

```json
{
  "ok": true,
  "fdte9kozfk780y1": {
    "template": "debian-7-x86_64",
    "lifetime": 1,
    "running": 0.05,
    "state": "running",
    "domain": "delivery.puppetlabs.net"
  }
}
```

This is in favor of #99.