### PR TITLE
Store token metadata in vmpooler__vm__ Redis hash

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -308,8 +308,15 @@ module Vmpooler
               backend.hset('vmpooler__active__' + key, vm, Time.now)
               backend.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
 
-              if Vmpooler::API.settings.config[:auth] and has_valid_token? and config['vm_lifetime_auth'].to_i > 0
-                backend.hset('vmpooler__vm__' + vm, 'lifetime', config['vm_lifetime_auth'].to_i)
+              if Vmpooler::API.settings.config[:auth] and has_valid_token?
+                backend.hset('vmpooler__vm__' + vm, 'token:token', request.env['HTTP_X_AUTH_TOKEN'])
+                backend.hset('vmpooler__vm__' + vm, 'token:user',
+                  backend.hget('vmpooler__token__' + request.env['HTTP_X_AUTH_TOKEN'], 'user')
+                )
+
+                if config['vm_lifetime_auth'].to_i > 0
+                  backend.hset('vmpooler__vm__' + vm, 'lifetime', config['vm_lifetime_auth'].to_i)
+                end
               end
 
               result[key] ||= {}

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -177,6 +177,7 @@ describe Vmpooler::API::V1 do
       app.settings.set :redis, redis
 
       allow(redis).to receive(:exists).and_return '1'
+      allow(redis).to receive(:hget).with('vmpooler__token__abcdefghijklmnopqrstuvwxyz012345', 'user').and_return 'jdoe'
       allow(redis).to receive(:hset).and_return '1'
       allow(redis).to receive(:sadd).and_return '1'
       allow(redis).to receive(:scard).and_return '5'


### PR DESCRIPTION
Stored as `token:token` and `token:user`.

```
> hgetall vmpooler__vm__l2c9zpoe6cj99yq
 1) "clone"
 2) "2015-04-30 19:11:14 -0700"
 3) "template"
 4) "debian-7-x86_64"
 5) "clone_time"
 6) "4.68"
 7) "check"
 8) "2015-04-30 19:13:11 -0700"
 9) "checkout"
10) "2015-04-30 19:15:12 -0700"
11) "token:token"
12) "c0hj5ho41n9lnvciws8wwkqxrl4c2954"
13) "token:user"
14) "sschneider"
15) "tag:beaker_version"
16) "2.10.0"
17) "tag:jenkins_build_url"
18) ""
19) "tag:department"
20) "unknown"
21) "tag:project"
22) "Beaker"
23) "tag:created_by"
24) "sschneider"
25) "destroy"
26) "2015-04-30 19:15:19 -0700"
```