### PR TITLE
(QENG-2518) Tag-filtering

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -37,6 +37,12 @@ module Vmpooler
       parsed_config[:graphite]['prefix'] ||= 'vmpooler'
     end
 
+    if parsed_config[:tagfilter]
+      parsed_config[:tagfilter].keys.each do |tag|
+        parsed_config[:tagfilter][tag] = Regexp.new(parsed_config[:tagfilter][tag])
+      end
+    end
+
     parsed_config[:uptime] = Time.now
 
     parsed_config

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -542,8 +542,13 @@ module Vmpooler
                 backend.hset('vmpooler__vm__' + params[:hostname], param, arg)
               when 'tags'
                 arg.keys.each do |tag|
-                    backend.hset('vmpooler__vm__' + params[:hostname], 'tag:' + tag, arg[tag])
-                    backend.hset('vmpooler__tag__' + Date.today.to_s, params[:hostname] + ':' + tag, arg[tag])
+                  if Vmpooler::API.settings.config[:tagfilter] and Vmpooler::API.settings.config[:tagfilter][tag]
+                    filter = Vmpooler::API.settings.config[:tagfilter][tag]
+                    arg[tag] = arg[tag].match(filter).captures.join
+                  end
+
+                  backend.hset('vmpooler__vm__' + params[:hostname], 'tag:' + tag, arg[tag])
+                  backend.hset('vmpooler__tag__' + Date.today.to_s, params[:hostname] + ':' + tag, arg[tag])
                 end
             end
           end

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -332,6 +332,23 @@ describe Vmpooler::API::V1 do
           expect(last_response.status).to eq(400)
         end
 
+      context '(tagfilter configured)' do
+        let(:config) { {
+          tagfilter: { 'url' => '(.*)\/' },
+        } }
+
+        it 'correctly filters tags' do
+          expect(redis).to receive(:hset).with("vmpooler__vm__testhost", "tag:url", "foo.com")
+
+          put "#{prefix}/vm/testhost", '{"tags":{"url":"foo.com/something.html"}}'
+
+          expect(last_response).to be_ok
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(last_response.body).to eq(JSON.pretty_generate({'ok' => true}))
+          expect(last_response.status).to eq(200)
+        end
+      end
+
       context '(auth not configured)' do
         let(:config) { { auth: false } }
 

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -106,6 +106,18 @@
     base: 'ou=users,dc=company,dc=com'
     user_object: 'uid'
 
+# :tagfilter:
+#
+# Filter tags by regular expression.
+
+# Example:
+#
+# This example demonstrates discarding everything after a '/' character for
+# the 'url' tag, transforming 'foo.com/something.html' to 'foo.com'.
+
+:tagfilter:
+  url: '(.*)\/'
+
 # :config:
 #
 # This section contains global configuration information.


### PR DESCRIPTION
This PR adds regular expression-based tag-filtering functionality.  Given this configuration stanza:

````yaml
:tagfilter:
  url: '(.*)\/'
````

...any 'url' tag will be truncated after the first matching '/' character.