### PR TITLE
Only filter regex matches

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -544,7 +544,7 @@ module Vmpooler
                 arg.keys.each do |tag|
                   if Vmpooler::API.settings.config[:tagfilter] and Vmpooler::API.settings.config[:tagfilter][tag]
                     filter = Vmpooler::API.settings.config[:tagfilter][tag]
-                    arg[tag] = arg[tag].match(filter).captures.join
+                    arg[tag] = arg[tag].match(filter).captures.join if arg[tag].match(filter)
                   end
 
                   backend.hset('vmpooler__vm__' + params[:hostname], 'tag:' + tag, arg[tag])

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -347,6 +347,17 @@ describe Vmpooler::API::V1 do
           expect(last_response.body).to eq(JSON.pretty_generate({'ok' => true}))
           expect(last_response.status).to eq(200)
         end
+
+        it 'doesn\'t eat tags not matching filter' do
+          expect(redis).to receive(:hset).with("vmpooler__vm__testhost", "tag:url", "foo.com")
+
+          put "#{prefix}/vm/testhost", '{"tags":{"url":"foo.com"}}'
+
+          expect(last_response).to be_ok
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(last_response.body).to eq(JSON.pretty_generate({'ok' => true}))
+          expect(last_response.status).to eq(200)
+        end
       end
 
       context '(auth not configured)' do


### PR DESCRIPTION
and a spec test for it.

Previously using the example shown in vmpooler.yaml.example was failing
to tag strings WITHOUT a '/' in them.