### PR TITLE
API /summary rework

### DIFF
--- a/lib/vmpooler/api/reroute.rb
+++ b/lib/vmpooler/api/reroute.rb
@@ -11,6 +11,10 @@ module Vmpooler
       call env.merge("PATH_INFO" => "/api/v#{api_version}/summary")
     end
 
+    get '/summary/:route/?:key?/?' do
+      call env.merge("PATH_INFO" => "/api/v#{api_version}/summary/#{params[:route]}/#{params[:key]}")
+    end
+
     post '/token/?' do
       call env.merge("PATH_INFO" => "/api/v#{api_version}/token")
     end


### PR DESCRIPTION
* moves the majority of summary-generation to helper methods
* implements `/summary/:route/:key` dynamic routes, eg.
  * `/summary/tag`
  * `/summary/tag/created_by`
  * `/summary/tag/created_by?from=2015-06-01`
  * `/summary/boot`
  * `/summary/clone`
  * `/summary/clone/duration?from=2015-05-29&to=2015-06-01`
  * ...and so on