### PR TITLE
(QENG-2636) Host snapshots

### DIFF
--- a/lib/vmpooler/api/reroute.rb
+++ b/lib/vmpooler/api/reroute.rb
@@ -50,6 +50,14 @@ module Vmpooler
     put '/vm/:hostname/?' do
       call env.merge("PATH_INFO" => "/api/v#{api_version}/vm/#{params[:hostname]}")
     end
+
+    post '/vm/:hostname/snapshot/?' do
+      call env.merge("PATH_INFO" => "/api/v#{api_version}/vm/#{params[:hostname]}/snapshot")
+    end
+
+    post '/vm/:hostname/snapshot/:snapshot/?' do
+      call env.merge("PATH_INFO" => "/api/v#{api_version}/vm/#{params[:hostname]}/snapshot/#{params[:snapshot]}")
+    end
   end
   end
 end

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -518,6 +518,8 @@ module Vmpooler
     post "#{api_prefix}/vm/:hostname/snapshot/?" do
       content_type :json
 
+      need_token! if Vmpooler::API.settings.config[:auth]
+
       status 404
       result = { 'ok' => false }
 
@@ -540,6 +542,8 @@ module Vmpooler
 
     post "#{api_prefix}/vm/:hostname/snapshot/:snapshot/?" do
       content_type :json
+
+      need_token! if Vmpooler::API.settings.config[:auth]
 
       status 404
       result = { 'ok' => false }

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -99,6 +99,14 @@ module Vmpooler
       base
     end
 
+    def find_snapshot(vm, snapshotname)
+      if vm.snapshot
+        get_snapshot_list(vm.snapshot.rootSnapshotList, snapshotname)
+      else
+        return []
+      end
+    end
+
     def find_vm(vmname)
       begin
         @connection.serviceInstance.CurrentTime
@@ -176,6 +184,20 @@ module Vmpooler
         recursive: true,
         type: ['VirtualMachine']
       )
+    end
+
+    def get_snapshot_list(tree, snapshotname)
+      snapshot = []
+
+      tree.each do |child|
+        if child.name == snapshotname
+          snapshot ||= child.snapshot
+        else
+          snapshot ||= get_snapshot_list(child.childSnapshotList, snapshotname)
+        end
+      end
+
+      snapshot
     end
 
     def close

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -102,8 +102,6 @@ module Vmpooler
     def find_snapshot(vm, snapshotname)
       if vm.snapshot
         get_snapshot_list(vm.snapshot.rootSnapshotList, snapshotname)
-      else
-        return []
       end
     end
 
@@ -187,7 +185,7 @@ module Vmpooler
     end
 
     def get_snapshot_list(tree, snapshotname)
-      snapshot = []
+      snapshot = nil
 
       tree.each do |child|
         if child.name == snapshotname

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -434,6 +434,9 @@ describe Vmpooler::API::V1 do
     end
 
     describe 'POST /vm/:hostname/snapshot' do
+      context '(auth not configured)' do
+        let(:config) { { auth: false } }
+
         it 'creates a snapshot' do
           expect(redis).to receive(:sadd)
 
@@ -444,9 +447,39 @@ describe Vmpooler::API::V1 do
           expect(JSON.parse(last_response.body)['testhost']['snapshot'].length).to be(32)
           expect(last_response.status).to eq(202)
         end
+      end
+
+      context '(auth configured)' do
+        let(:config) { { auth: true } }
+
+        it 'returns a 401 if not authed' do
+          post "#{prefix}/vm/testhost/snapshot"
+
+          expect(last_response).not_to be_ok
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(last_response.body).to eq(JSON.pretty_generate({'ok' => false}))
+          expect(last_response.status).to eq(401)
+        end
+
+        it 'creates a snapshot if authed' do
+          expect(redis).to receive(:sadd)
+
+          post "#{prefix}/vm/testhost/snapshot", "", {
+            'HTTP_X_AUTH_TOKEN' => 'abcdefghijklmnopqrstuvwxyz012345'
+          }
+
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(JSON.parse(last_response.body)['ok']).to eq(true)
+          expect(JSON.parse(last_response.body)['testhost']['snapshot'].length).to be(32)
+          expect(last_response.status).to eq(202)
+        end
+      end
     end
 
     describe 'POST /vm/:hostname/snapshot/:snapshot' do
+      context '(auth not configured)' do
+        let(:config) { { auth: false } }
+
         it 'reverts to a snapshot' do
           expect(redis).to receive(:exists).with('vmpooler__vm__testhost').and_return(1)
           expect(redis).to receive(:hget).with('vmpooler__vm__testhost', 'snapshot:testsnapshot').and_return(1)
@@ -458,6 +491,35 @@ describe Vmpooler::API::V1 do
           expect(last_response.body).to include('"ok": true')
           expect(last_response.status).to eq(202)
         end
+      end
+
+      context '(auth configured)' do
+        let(:config) { { auth: true } }
+
+        it 'returns a 401 if not authed' do
+          post "#{prefix}/vm/testhost/snapshot"
+
+          expect(last_response).not_to be_ok
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(last_response.body).to eq(JSON.pretty_generate({'ok' => false}))
+          expect(last_response.status).to eq(401)
+        end
+
+        it 'reverts to a snapshot if authed' do
+          expect(redis).to receive(:exists).with('vmpooler__vm__testhost').and_return(1)
+          expect(redis).to receive(:hget).with('vmpooler__vm__testhost', 'snapshot:testsnapshot').and_return(1)
+          expect(redis).to receive(:sadd)
+
+          post "#{prefix}/vm/testhost/snapshot/testsnapshot", "", {
+            'HTTP_X_AUTH_TOKEN' => 'abcdefghijklmnopqrstuvwxyz012345'
+          }
+
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(last_response.body).to include('"ok": true')
+          expect(last_response.status).to eq(202)
+        end
+      end
+
     end
   end
 

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -432,6 +432,33 @@ describe Vmpooler::API::V1 do
         end
       end
     end
+
+    describe 'POST /vm/:hostname/snapshot' do
+        it 'creates a snapshot' do
+          expect(redis).to receive(:sadd)
+
+          post "#{prefix}/vm/testhost/snapshot"
+
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(JSON.parse(last_response.body)['ok']).to eq(true)
+          expect(JSON.parse(last_response.body)['testhost']['snapshot'].length).to be(32)
+          expect(last_response.status).to eq(202)
+        end
+    end
+
+    describe 'POST /vm/:hostname/snapshot/:snapshot' do
+        it 'reverts to a snapshot' do
+          expect(redis).to receive(:exists).with('vmpooler__vm__testhost').and_return(1)
+          expect(redis).to receive(:hget).with('vmpooler__vm__testhost', 'snapshot:testsnapshot').and_return(1)
+          expect(redis).to receive(:sadd)
+
+          post "#{prefix}/vm/testhost/snapshot/testsnapshot"
+
+          expect(last_response.header['Content-Type']).to eq('application/json')
+          expect(last_response.body).to include('"ok": true')
+          expect(last_response.status).to eq(202)
+        end
+    end
   end
 
 end

--- a/spec/vmpooler/pool_manager_spec.rb
+++ b/spec/vmpooler/pool_manager_spec.rb
@@ -211,4 +211,72 @@ describe 'Pool Manager' do
     end
   end
 
+  describe '#_create_vm_snapshot' do
+    let(:snapshot_manager) { 'snapshot_manager' }
+    let(:pool_helper) { double('snapshot_manager') }
+    let(:vsphere) { {snapshot_manager => pool_helper} }
+
+    before do
+      expect(subject).not_to be_nil
+      $vsphere = vsphere
+    end
+
+    context '(valid host)' do
+      let(:vm_host) { double('vmhost') }
+
+      it 'creates a snapshot' do
+        expect(pool_helper).to receive(:find_vm).and_return vm_host
+        expect(logger).to receive(:log)
+        expect(vm_host).to receive_message_chain(:CreateSnapshot_Task, :wait_for_completion)
+        expect(redis).to receive(:hset).with('vmpooler__vm__testvm', 'snapshot:testsnapshot', Time.now.to_s)
+        expect(logger).to receive(:log)
+
+        subject._create_vm_snapshot('testvm', 'testsnapshot')
+      end
+    end
+  end
+
+  describe '#_revert_vm_snapshot' do
+    let(:snapshot_manager) { 'snapshot_manager' }
+    let(:pool_helper) { double('snapshot_manager') }
+    let(:vsphere) { {snapshot_manager => pool_helper} }
+
+    before do
+      expect(subject).not_to be_nil
+      $vsphere = vsphere
+    end
+
+    context '(valid host)' do
+      let(:vm_host) { double('vmhost') }
+      let(:vm_snapshot) { double('vmsnapshot') }
+
+      it 'reverts a snapshot' do
+        expect(pool_helper).to receive(:find_vm).and_return vm_host
+        expect(pool_helper).to receive(:find_snapshot).and_return vm_snapshot
+        expect(logger).to receive(:log)
+        expect(vm_snapshot).to receive_message_chain(:RevertToSnapshot_Task, :wait_for_completion)
+        expect(logger).to receive(:log)
+
+        subject._revert_vm_snapshot('testvm', 'testsnapshot')
+      end
+    end
+  end
+
+  describe '#_check_snapshot_queue' do
+    let(:pool_helper) { double('pool') }
+    let(:vsphere) { {pool => pool_helper} }
+
+    before do
+      expect(subject).not_to be_nil
+      $vsphere = vsphere
+    end
+
+    it 'checks appropriate redis queues' do
+      expect(redis).to receive(:spop).with('vmpooler__tasks__snapshot')
+      expect(redis).to receive(:spop).with('vmpooler__tasks__snapshot-revert')
+
+      subject._check_snapshot_queue
+    end
+  end
+
 end


### PR DESCRIPTION
This PR introduces host (VM) snapshotting support.  Example workflow:

1) Request a VM
````
$ curl -d '{"debian-7-x86_64":"1"}' --url vmpooler-dev/vm
{
  "ok": true,
  "debian-7-x86_64": {
    "ok": true,
    "hostname": "cxd6n45t1pd5s4j"
  },
  "domain": "delivery.puppetlabs.net"
}
````

2) Take a snapshot
````
This command will return a snapshot ID ("fjgd9l9okym8647gmjnznky5sklji0r3")

$ curl -d --url vmpooler-dev/vm/cxd6n45t1pd5s4j/snapshot
{
  "ok": true,
  "cxd6n45t1pd5s4j": {
    "snapshot": "fjgd9l9okym8647gmjnznky5sklji0r3"
  }
}
````

3) The vmpooler pooler_manager component sees the snapshot-creation task, and snapshots the VM in the background
````
[2015-05-01 12:35:02] [ ] [snapshot_manager] 'cxd6n45t1pd5s4j' is being snapshotted
[2015-05-01 12:39:04] [+] [snapshot_manager] 'cxd6n45t1pd5s4j' snapshot created in 242.77 seconds
````

4) You can query the VM itself; the GET /vm/:hostname endpoint will show a snapshot once pool_manager has finished the snapshotting task
````
$ curl --url vmpooler-dev/vm/cxd6n45t1pd5s4j
{
  "ok": true,
  "cxd6n45t1pd5s4j": {
    "template": "debian-7-x86_64",
    "lifetime": 1,
    "running": 0.08,
    "snapshots": [
      "fjgd9l9okym8647gmjnznky5sklji0r3"
    ],
    "domain": "delivery.puppetlabs.net"
  }
}
````

4) Change something on the VM
````
$ ssh root@cxd6n45t1pd5s4j
root@cxd6n45t1pd5s4j's password:
Linux debian-7-64 3.2.0-4-amd64 #1 SMP Debian 3.2.65-1 x86_64 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright. 

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Tue Mar 31 08:33:05 2015
root@cxd6n45t1pd5s4j:~# echo "This VM has been modified." >/etc/motd
root@cxd6n45t1pd5s4j:~# cat /etc/motd
This VM has been modified.
````

5) Revert the VM back to the snapshot we took earlier
````
$ curl -d --url vmpooler-dev/vm/cxd6n45t1pd5s4j/snapshot/fjgd9l9okym8647gmjnznky5sklji0r3
{
  "ok": true
}
````

6) pool_manager reverts the VM
````
[2015-05-01 12:41:52] [ ] [snapshot_manager] 'cxd6n45t1pd5s4j' is being reverted to snapshot 'fjgd9l9okym8647gmjnznky5sklji0r3'
[2015-05-01 12:41:58] [<] [snapshot_manager] 'cxd6n45t1pd5s4j' reverted to snapshot in 6.86 seconds
````

7) Verify that the changes in step 4 do not persist
````
$ ssh root@cxd6n45t1pd5s4j
root@cxd6n45t1pd5s4j's password:
Linux debian-7-64 3.2.0-4-amd64 #1 SMP Debian 3.2.65-1 x86_64 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright. 

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: Tue Mar 31 08:33:05 2015
root@cxd6n45t1pd5s4j:~# cat /etc/motd 

The programs included with the Debian GNU/Linux system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright. 

Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
````