### PR TITLE
(QENG-1304) vmpooler should require an auth key for VM destruction

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -438,10 +438,14 @@ module Vmpooler
 
       params[:hostname] = hostname_shorten(params[:hostname], config['domain'])
 
-      pools.each do |pool|
-        if backend.sismember('vmpooler__running__' + pool['name'], params[:hostname])
-          backend.srem('vmpooler__running__' + pool['name'], params[:hostname])
-          backend.sadd('vmpooler__completed__' + pool['name'], params[:hostname])
+      if backend.exists('vmpooler__vm__' + params[:hostname])
+        rdata = backend.hgetall('vmpooler__vm__' + params[:hostname])
+
+        need_token! if rdata['token:token']
+
+        if backend.sismember('vmpooler__running__' + rdata['template'], params[:hostname])
+          backend.srem('vmpooler__running__' + rdata['template'], params[:hostname])
+          backend.sadd('vmpooler__completed__' + rdata['template'], params[:hostname])
 
           status 200
           result['ok'] = true


### PR DESCRIPTION
Note that this PR does not require checkout and destruction tokens to match.  This mimics the existing token behavior of `PUT /vm/:hostname`.  I'd like to enforce token-matching for both routes in a follow-up PR.