### PR TITLE
Track token use times

### DIFF
--- a/lib/vmpooler/api/helpers.rb
+++ b/lib/vmpooler/api/helpers.rb
@@ -15,7 +15,11 @@ module Vmpooler
       end
 
       def validate_token(backend)
-        return if valid_token?(backend)
+        if valid_token?(backend)
+          backend.hset('vmpooler__token__' + request.env['HTTP_X_AUTH_TOKEN'], 'last', Time.now)
+
+          return true
+        end
 
         content_type :json
 

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -49,7 +49,7 @@ describe Vmpooler::API::V1 do
 
         it 'returns a list of tokens if authed' do
           expect(redis).to receive(:keys).with('vmpooler__token__*').and_return(["vmpooler__token__abc"])
-          expect(redis).to receive(:hgetall).with('vmpooler__token__abc').and_return({"user" => "admin", "timestamp" => "now"})
+          expect(redis).to receive(:hgetall).with('vmpooler__token__abc').and_return({"user" => "admin", "created" => "now"})
 
           authorize 'admin', 's3cr3t'
 


### PR DESCRIPTION
**This PR is dependent on #123 being merged.**

* rename the Redis token 'timestamp' var to 'created'
* update the Redis token 'last' var when token is successfully validated
* expose the Redis token 'last' var in GET /token route

````
$ curl k -X GET -u jdoe --url https://vmpooler/api/v1/token
Enter host password for user 'jdoe':
````
````json
{
  "ok": true,
  "a9znth9dn01t416hrguu56ze37t790bl": {
    "created": "2015-04-30 19:09:20 -0700",
    "last": "never"
  },
  "amedivt3p21q7y1d5w7mcunukwxmkh6n": {
    "created": "2015-08-19 11:36:10 -0700",
    "last": "2015-08-19 12:37:40 -0700"
  }
}
````

````
$ curl -k -X GET -u jdoe --url https://vmpooler/api/v1/token/amedivt3p21q7y1d5w7mcunukwxmkh6n
Enter host password for user 'jdoe':
````
````json
{
  "ok": true,
  "amedivt3p21q7y1d5w7mcunukwxmkh6n": {
    "user": "jdoe",
    "created": "2015-08-19 11:36:10 -0700",
    "last": "2015-08-19 12:37:40 -0700"
  }
}
````