### PR TITLE
(maint) Remove duplicate (nested) "ok" responses

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -295,8 +295,6 @@ module Vmpooler
         jdata.each do |key, val|
           result[key] ||= {}
 
-          result[key]['ok'] = true ##
-
           val.to_i.times do |_i|
             vm = backend.spop('vmpooler__ready__' + key)
 
@@ -320,8 +318,6 @@ module Vmpooler
 
               result[key] ||= {}
 
-              result[key]['ok'] = true ##
-
               if result[key]['hostname']
                 result[key]['hostname'] = [result[key]['hostname']] unless result[key]['hostname'].is_a?(Array)
                 result[key]['hostname'].push(vm)
@@ -329,8 +325,6 @@ module Vmpooler
                 result[key]['hostname'] = vm
               end
             else
-              result[key]['ok'] = false ##
-
               status 503
               result['ok'] = false
             end
@@ -373,8 +367,6 @@ module Vmpooler
         params[:template].split('+').each do |template|
           result[template] ||= {}
 
-          result[template]['ok'] = true ##
-
           vm = backend.spop('vmpooler__ready__' + template)
 
           unless vm.nil?
@@ -404,8 +396,6 @@ module Vmpooler
               result[template]['hostname'] = vm
             end
           else
-            result[template]['ok'] = false ##
-
             status 503
             result['ok'] = false
           end

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -213,7 +213,6 @@ describe Vmpooler::API::V1 do
         expected = {
           ok: true,
           pool1: {
-            ok: true,
             hostname: 'abcdefghijklmnop'
           }
         }
@@ -229,11 +228,9 @@ describe Vmpooler::API::V1 do
         expected = {
           ok: true,
           pool1: {
-            ok: true,
             hostname: 'abcdefghijklmnop'
           },
           pool2: {
-            ok: true,
             hostname: 'qrstuvwxyz012345'
           }
         }
@@ -256,7 +253,6 @@ describe Vmpooler::API::V1 do
           expected = {
             ok: true,
             pool1: {
-              ok: true,
               hostname: 'abcdefghijklmnop'
             }
           }
@@ -280,7 +276,6 @@ describe Vmpooler::API::V1 do
           expected = {
             ok: true,
             pool1: {
-              ok: true,
               hostname: 'abcdefghijklmnop'
             }
           }
@@ -298,7 +293,6 @@ describe Vmpooler::API::V1 do
           expected = {
             ok: true,
             pool1: {
-              ok: true,
               hostname: 'abcdefghijklmnop'
             }
           }


### PR DESCRIPTION
As we approach an "official" v1.0.0 of the API I'd like to remove some old
nested "ok" responses.  These were left in as the Beaker vmpooler
hypervisor used them, but I long-ago patched that code and I think it's
time to deprecate these.