### PR TITLE
(QENG-2952) Check that SSH is available

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -31,6 +31,14 @@ module Vmpooler
       host = $vsphere[pool].find_vm(vm)
 
       if host
+        begin
+          Timeout.timeout(5) do
+            TCPSocket.new vm, 22
+          end
+        rescue
+          fail_pending_vm(vm, pool, timeout)
+        end
+
         move_pending_vm_to_ready(vm, pool, host)
       else
         fail_pending_vm(vm, pool, timeout)

--- a/spec/vmpooler/pool_manager_spec.rb
+++ b/spec/vmpooler/pool_manager_spec.rb
@@ -35,10 +35,14 @@ describe 'Pool Manager' do
 
     context 'host is in pool' do
       let(:vm_finder) { double('vm_finder') }
+      let(:tcpsocket) { double('TCPSocket') }
 
       it 'calls move_pending_vm_to_ready' do
+        stub_const("TCPSocket", tcpsocket)
+
         allow(pool_helper).to receive(:find_vm).and_return(vm_finder)
         allow(vm_finder).to receive(:summary).and_return(nil)
+        allow(tcpsocket).to receive(:new).and_return(true)
 
         expect(vm_finder).to receive(:summary).once
         expect(redis).not_to receive(:hget).with(String, 'clone')


### PR DESCRIPTION
SSH should be available before a VM is moved from the 'pending' queue to
'ready'.

`check_ssh` should probably be a function in the tradition of DRY; I'm
going to hopefully follow up this PR with a `Vmpooler::Utility` library.