### PR TITLE
(maint) Move VM Only When SSH Check Succeeds

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -35,11 +35,10 @@ module Vmpooler
           Timeout.timeout(5) do
             TCPSocket.new vm, 22
           end
+          move_pending_vm_to_ready(vm, pool, host)
         rescue
           fail_pending_vm(vm, pool, timeout)
         end
-
-        move_pending_vm_to_ready(vm, pool, host)
       else
         fail_pending_vm(vm, pool, timeout)
       end


### PR DESCRIPTION
An SSH check was added before moving a VM from pending to ready.
However, the result of that check did not matter and move_pending would
still be called. This moves the move_pending call to within the begin
block that holds the SSH check. If the check fails, then only
fail_pending will be called.