### PR TITLE
(MAINT) Remove Ping Check on Running VMs

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -149,12 +149,6 @@ module Vmpooler
       if host
         queue_from, queue_to = 'running', 'completed'
 
-        # Check that VM is powered on
-        if (host.runtime) &&
-            (host.runtime.powerState != 'poweredOn')
-          move_vm_queue(pool, vm, queue_from, queue_to, 'appears to be powered off or dead')
-        end
-
         # Check that VM is within defined lifetime
         checkouttime = $redis.hget('vmpooler__active__' + pool, vm)
         if checkouttime

--- a/spec/vmpooler/pool_manager_spec.rb
+++ b/spec/vmpooler/pool_manager_spec.rb
@@ -168,14 +168,14 @@ describe 'Pool Manager' do
     context 'valid host' do
       let(:vm_host) { double('vmhost') }
 
-      it 'moves vm when not poweredOn' do
+      it 'does not move vm when not poweredOn' do
         allow(pool_helper).to receive(:find_vm).and_return vm_host
         allow(vm_host).to receive(:runtime).and_return true
         allow(vm_host).to receive_message_chain(:runtime, :powerState).and_return 'poweredOff'
 
         expect(redis).to receive(:hget)
-        expect(redis).to receive(:smove)
-        expect(logger).to receive(:log).with('d', "[!] [#{pool}] '#{vm}' appears to be powered off or dead")
+        expect(redis).not_to receive(:smove)
+        expect(logger).not_to receive(:log).with('d', "[!] [#{pool}] '#{vm}' appears to be powered off or dead")
 
         subject._check_running_vm(vm, pool, timeout)
       end


### PR DESCRIPTION
Prior to this commit, a running VM could fail a ping check and be destroyed. This causes issues when network hiccups occur or the machine is performing a reboot.

A VM that is in a ready state will now be destroyed when handed back or it hits the lifetime TTL.