### PR TITLE
(QENG-2995) Display associated VMs in GET /token/:token endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,8 +43,7 @@ Enter host password for user 'jdoe':
 Get information about an existing token (including associated VMs).
 
 ```
-$ curl -u jdoe --url vmpooler.company.com/api/v1/token/utpg2i2xswor6h8ttjhu3d47z53yy47y
-Enter host password for user 'jdoe':
+$ curl --url vmpooler.company.com/api/v1/token/utpg2i2xswor6h8ttjhu3d47z53yy47y
 ```
 ```json
 {

--- a/API.md
+++ b/API.md
@@ -40,7 +40,7 @@ Enter host password for user 'jdoe':
 
 ##### GET /token/&lt;token&gt;
 
-Get information about an existing token.
+Get information about an existing token (including associated VMs).
 
 ```
 $ curl -u jdoe --url vmpooler.company.com/api/v1/token/utpg2i2xswor6h8ttjhu3d47z53yy47y
@@ -51,7 +51,14 @@ Enter host password for user 'jdoe':
   "ok": true,
   "utpg2i2xswor6h8ttjhu3d47z53yy47y": {
     "user": "jdoe",
-    "timestamp": "2015-04-28 19:17:47 -0700"
+    "created": "2015-04-28 19:17:47 -0700",
+    "last": "2015-11-04 12:28:37 -0700",
+    "vms": {
+      "running": [
+        "dqs4914g2wjyy5w",
+        "hul7ib0ssr0f4o0"
+      ]
+    }
   }
 }
 ```

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -209,6 +209,17 @@ module Vmpooler
 
         if not token.nil? and not token.empty?
           status 200
+
+          pools.each do |pool|
+            backend.smembers('vmpooler__running__' + pool['name']).each do |vm|
+              if backend.hget('vmpooler__vm__' + vm, 'token:token') == params[:token]
+                token['vms'] ||= {}
+                token['vms']['running'] ||= []
+                token['vms']['running'].push(vm)
+              end
+            end
+          end
+
           result = { 'ok' => true, params[:token] => token }
         else
           status 404

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -201,10 +201,6 @@ module Vmpooler
       result = { 'ok' => false }
 
       if Vmpooler::API.settings.config[:auth]
-        status 401
-
-        need_auth!
-
         token = backend.hgetall('vmpooler__token__' + params[:token])
 
         if not token.nil? and not token.empty?
@@ -221,8 +217,6 @@ module Vmpooler
           end
 
           result = { 'ok' => true, params[:token] => token }
-        else
-          status 404
         end
       end
 

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -127,18 +127,10 @@ describe Vmpooler::API::V1 do
           ]
         } }
 
-        it 'returns a 401 if not authed' do
-          get "#{prefix}/token/this"
-
-          expect_json(ok = false, http = 401)
-        end
-
-        it 'returns a token if authed' do
+        it 'returns a token' do
           expect(redis).to receive(:hgetall).with('vmpooler__token__this').and_return({'user' => 'admin'})
           expect(redis).to receive(:smembers).with('vmpooler__running__pool1').and_return(['vmhostname'])
           expect(redis).to receive(:hget).with('vmpooler__vm__vmhostname', 'token:token').and_return('this')
-
-          authorize 'admin', 's3cr3t'
 
           get "#{prefix}/token/this"
 


### PR DESCRIPTION
This is deployed on `vmpooler-dev`.

````
$ curl -k -X GET --url https://vmpooler-dev.delivery.puppetlabs.net/api/v1/token/cxig75je6dzjjinbg5oxmfjup63libs5
````
````json
{
  "ok": true,
  "cxig75je6dzjjinbg5oxmfjup63libs5": {
    "user": "sschneider",
    "created": "2015-11-03 14:56:57 -0800",
    "last": "2015-11-04 12:28:37 -0800",
    "vms": {
      "running": [
        "dqs4914g2wjyy5w",
        "hul7ib0ssr0f4o0"
      ]
    }
  }
}
````