### PR TITLE
(QENG-2807) Allow pool 'alias' names

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -33,6 +33,20 @@ module Vmpooler
     parsed_config[:config]['vm_checktime'] ||= 15
     parsed_config[:config]['vm_lifetime']  ||= 24
 
+    # Create an index of pool aliases
+    parsed_config[:pools].each do |pool|
+      if pool['alias']
+        if pool['alias'].kind_of?(Array)
+          pool['alias'].each do |a|
+            parsed_config[:alias] ||= {}
+            parsed_config[:alias][a] = pool['name']
+          end
+        elsif pool['alias'].kind_of?(String)
+          parsed_config[:alias][pool['alias']] = pool['name']
+        end
+      end
+    end
+
     if parsed_config[:graphite]['server']
       parsed_config[:graphite]['prefix'] ||= 'vmpooler'
     end

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -190,7 +190,8 @@ describe Vmpooler::API::V1 do
       pools: [
         {'name' => 'pool1', 'size' => 5},
         {'name' => 'pool2', 'size' => 10}
-      ]
+      ],
+      alias: { 'poolone' => 'pool1' }
     } }
 
     before do
@@ -220,6 +221,31 @@ describe Vmpooler::API::V1 do
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
 
         expect_json(ok = true, http = 200)
+      end
+
+      it 'returns a single VM for an alias' do
+        expect(redis).to receive(:exists).with("vmpooler__ready__poolone").and_return(false)
+
+        post "#{prefix}/vm", '{"poolone":"1"}'
+
+        expected = {
+          ok: true,
+          pool1: {
+            hostname: 'abcdefghijklmnop'
+          }
+        }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+        expect_json(ok = true, http = 200)
+      end
+
+      it 'fails on nonexistant pools' do
+        expect(redis).to receive(:exists).with("vmpooler__ready__poolpoolpool").and_return(false)
+
+        post "#{prefix}/vm", '{"poolpoolpool":"1"}'
+
+        expect_json(ok = false, http = 404)
       end
 
       it 'returns multiple VMs' do
@@ -289,6 +315,158 @@ describe Vmpooler::API::V1 do
           expect(redis).not_to receive(:hset).with("vmpooler__vm__abcdefghijklmnop", "lifetime", 2)
 
           post "#{prefix}/vm", '{"pool1":"1"}'
+
+          expected = {
+            ok: true,
+            pool1: {
+              hostname: 'abcdefghijklmnop'
+            }
+          }
+
+          expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+          expect_json(ok = true, http = 200)
+        end
+      end
+    end
+  end
+
+  describe '/vm/:template' do
+    let(:redis)  { double('redis') }
+    let(:prefix) { '/api/v1' }
+    let(:config) { {
+      config: {
+        'site_name' => 'test pooler',
+        'vm_lifetime_auth' => 2
+      },
+      pools: [
+        {'name' => 'pool1', 'size' => 5},
+        {'name' => 'pool2', 'size' => 10}
+      ],
+      alias: { 'poolone' => 'pool1' }
+    } }
+
+    before do
+      app.settings.set :config, config
+      app.settings.set :redis, redis
+
+      allow(redis).to receive(:exists).and_return '1'
+      allow(redis).to receive(:hget).with('vmpooler__token__abcdefghijklmnopqrstuvwxyz012345', 'user').and_return 'jdoe'
+      allow(redis).to receive(:hset).and_return '1'
+      allow(redis).to receive(:sadd).and_return '1'
+      allow(redis).to receive(:scard).and_return '5'
+      allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
+      allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return 'qrstuvwxyz012345'
+    end
+
+    describe 'POST /vm/:template' do
+      it 'returns a single VM' do
+        post "#{prefix}/vm/pool1", ''
+
+        expected = {
+          ok: true,
+          pool1: {
+            hostname: 'abcdefghijklmnop'
+          }
+        }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+        expect_json(ok = true, http = 200)
+      end
+
+      it 'returns a single VM for an alias' do
+        expect(redis).to receive(:exists).with("vmpooler__ready__poolone").and_return(false)
+
+        post "#{prefix}/vm/poolone", ''
+
+        expected = {
+          ok: true,
+          pool1: {
+            hostname: 'abcdefghijklmnop'
+          }
+        }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+        expect_json(ok = true, http = 200)
+      end
+
+      it 'fails on nonexistant pools' do
+        expect(redis).to receive(:exists).with("vmpooler__ready__poolpoolpool").and_return(false)
+
+        post "#{prefix}/vm/poolpoolpool", ''
+
+        expect_json(ok = false, http = 404)
+      end
+
+      it 'returns multiple VMs' do
+        post "#{prefix}/vm/pool1+pool2", ''
+
+        expected = {
+          ok: true,
+          pool1: {
+            hostname: 'abcdefghijklmnop'
+          },
+          pool2: {
+            hostname: 'qrstuvwxyz012345'
+          }
+        }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+        expect_json(ok = true, http = 200)
+      end
+
+      context '(auth not configured)' do
+        let(:config) { { auth: false } }
+
+        it 'does not extend VM lifetime if auth token is provided' do
+          expect(redis).not_to receive(:hset).with("vmpooler__vm__abcdefghijklmnop", "lifetime", 2)
+
+          post "#{prefix}/vm/pool1", '', {
+            'HTTP_X_AUTH_TOKEN' => 'abcdefghijklmnopqrstuvwxyz012345'
+          }
+
+          expected = {
+            ok: true,
+            pool1: {
+              hostname: 'abcdefghijklmnop'
+            }
+          }
+
+          expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+          expect_json(ok = true, http = 200)
+        end
+      end
+
+      context '(auth configured)' do
+        let(:config) { { auth: true } }
+
+        it 'extends VM lifetime if auth token is provided' do
+          expect(redis).to receive(:hset).with("vmpooler__vm__abcdefghijklmnop", "lifetime", 2).once
+
+          post "#{prefix}/vm/pool1", '', {
+            'HTTP_X_AUTH_TOKEN' => 'abcdefghijklmnopqrstuvwxyz012345'
+          }
+
+          expected = {
+            ok: true,
+            pool1: {
+              hostname: 'abcdefghijklmnop'
+            }
+          }
+
+          expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+          expect_json(ok = true, http = 200)
+        end
+
+        it 'does not extend VM lifetime if auth token is not provided' do
+          expect(redis).not_to receive(:hset).with("vmpooler__vm__abcdefghijklmnop", "lifetime", 2)
+
+          post "#{prefix}/vm/pool1", ''
 
           expected = {
             ok: true,

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -188,6 +188,10 @@
 #     The name of the pool.
 #     (required)
 #
+#   - alias
+#     Other names this pool can be requested as.
+#     (optional)
+#
 #   - template
 #     The template or virtual machine target to spawn clones from.
 #     (required)
@@ -221,6 +225,7 @@
 
 :pools:
   - name: 'debian-7-i386'
+    alias: [ 'debian-7-32' ]
     template: 'Templates/debian-7-i386'
     folder: 'Pooled VMs/debian-7-i386'
     datastore: 'vmstorage'
@@ -228,6 +233,7 @@
     timeout: 15
     ready_ttl: 1440
   - name: 'debian-7-x86_64'
+    alias: [ 'debian-7-64', 'debian-7-amd64' ]
     template: 'Templates/debian-7-x86_64'
     folder: 'Pooled VMs/debian-7-x86_64'
     datastore: 'vmstorage'


### PR DESCRIPTION
The following pool configuration would allow a pool to be aliased in POST requests as '`centos-6-x86_64`', '`centos-6-amd64`', or '`centos-6-64`':

````yaml
- name: 'centos-6-x86_64'
  alias: [ 'centos-6-amd64', 'centos-6-64' ]
  template: 'templates/centos-6-x86_64'
  folder: 'vmpooler/centos-6-x86_64'
  datastore: 'instance1'
  size: 5
````

The `alias` configuration can be either a string or an array.

Note that even when requesting an alias, the pool's `name` is returned in the JSON response:

````
$ curl -d '{"centos-6-64":"1"}' --url vmpooler/api/v1/vm
````
````json
{
  "ok": true,
  "centos-6-x86_64": {
    "hostname": "cuna2qeahwlzji7"
  },
  "domain": "company.com"
}
````