### PR TITLE
add guestinfo.hostname to VirtualMachineConfigSpecs

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -197,13 +197,19 @@ module Vmpooler
         $redis.hset('vmpooler__vm__' + vm['hostname'], 'template', vm['template'])
 
         # Annotate with creation time, origin template, etc.
+        # Add extraconfig options that can be queried by vmtools
         configSpec = RbVmomi::VIM.VirtualMachineConfigSpec(
           annotation: JSON.pretty_generate(
               name: vm['hostname'],
               created_by: $config[:vsphere]['username'],
               base_template: vm['template'],
               creation_timestamp: Time.now.utc
-           )
+          ),
+          extraConfig: [
+              { key: 'guestinfo.hostname',
+                value: vm['hostname']
+              }
+          ]
         )
 
         # Choose a clone target


### PR DESCRIPTION
This commit adds a custom guestinfo keyword and hostname variable
that allows the VMware Tools to query the hostname.

```
root@akyjym751lr8cu3:~# vmtoolsd --cmd "info-get guestinfo.hostname"
akyjym751lr8cu3
```

This should allow us some flexibility in moving away from the requirement to talk to vCenter during bootstrap of a pooler VM in order to obtain the hostname.