### PR TITLE
Updated YAML config variables in create_template_deltas.rb

### DIFF
--- a/scripts/create_template_deltas.rb
+++ b/scripts/create_template_deltas.rb
@@ -22,12 +22,12 @@ def create_template_deltas( folder )
   abort 'No config file (./vmpooler.yaml or ~/.vmpooler) found!' unless config
 
   vim = RbVmomi::VIM.connect(
-    :host     => config[ :vsphere ][ :server ],
-    :user     => config[ :vsphere ][ :username ],
-    :password => config[ :vsphere ][ :password ],
+    :host     => config[ :vsphere ][ "server" ],
+    :user     => config[ :vsphere ][ "username" ],
+    :password => config[ :vsphere ][ "password" ],
     :ssl      => true,
     :insecure => true,
-  ) or abort "Unable to connect to #{config[ :vsphere ][ :server ]}!"
+  ) or abort "Unable to connect to #{config[ :vsphere ][ "server" ]}!"
 
   containerView = vim.serviceContent.viewManager.CreateContainerView( {
     :container => vim.serviceContent.rootFolder,


### PR DESCRIPTION
The symbol notation for the YAML variables "server," "username," and, "password," were not working for me.  When changing them to strings the script seems to work.