### PR TITLE
(QENG-3376) Allow lifetime to be set per-pool

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -61,8 +61,8 @@ module Vmpooler
             backend.hget('vmpooler__token__' + request.env['HTTP_X_AUTH_TOKEN'], 'user')
           )
 
-          if config['vm_lifetime_auth'].to_i > 0
-            backend.hset('vmpooler__vm__' + vm, 'lifetime', config['vm_lifetime_auth'].to_i)
+          if (pool['vm_lifetime_auth'] || config['vm_lifetime_auth']).to_i > 0
+            backend.hset('vmpooler__vm__' + vm, 'lifetime', (pool['vm_lifetime_auth'] || config['vm_lifetime_auth']).to_i)
           end
         end
 
@@ -429,7 +429,7 @@ module Vmpooler
         result[params[:hostname]] = {}
 
         result[params[:hostname]]['template'] = rdata['template']
-        result[params[:hostname]]['lifetime'] = (rdata['lifetime'] || config['vm_lifetime']).to_i
+        result[params[:hostname]]['lifetime'] = (rdata['lifetime'] || pool['vm_lifetime'] || config['vm_lifetime']).to_i
 
         if rdata['destroy']
           result[params[:hostname]]['running'] = ((Time.parse(rdata['destroy']) - Time.parse(rdata['checkout'])) / 60 / 60).round(2)

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -220,6 +220,14 @@
 #   - ready_ttl
 #     How long (in minutes) to keep VMs in 'ready' queues before destroying.
 #     (optional)
+#
+#   - vm_lifetime
+#     How long (in hours) to keep VMs in 'running' queues before destroying.
+#     (optional; default: '24')
+#
+#   - vm_lifetime_auth
+#     Same as vm_lifetime, but applied if a valid authentication token is
+#     included during the request.
 
 # Example:
 
@@ -240,4 +248,6 @@
     size: 5
     timeout: 15
     ready_ttl: 1440
+    vm_lifetime: 1
+    vm_lifetime_auth: 4
 


### PR DESCRIPTION
At current vm_lifetime and vm_lifetime_auth are configured globally only.  This change allows that value to be set/overridden per pool.