### PR TITLE
Allow new disks to be added to running VMs via vmpooler API

### DIFF
--- a/API.md
+++ b/API.md
@@ -226,6 +226,46 @@ $ curl -X DELETE --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6
 }
 ```
 
+#### Adding additional disk(s)
+
+##### POST /vm/&lt;hostname&gt;/disk/&lt;size&gt;
+
+Add an additional disk to a running VM.
+
+````
+$ curl -X POST -H X-AUTH-TOKEN:a9znth9dn01t416hrguu56ze37t790bl --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6/disk/8
+````
+````json
+{
+  "ok": true,
+  "fq6qlpjlsskycq6": {
+    "disk": "+8gb"
+  }
+}
+````
+
+Provisioning and attaching disks can take a moment, but once the task completes it will be reflected in a `GET /vm/<hostname>` query:
+
+````
+$ curl --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6
+````
+````json
+{
+  "ok": true,
+  "fq6qlpjlsskycq6": {
+    "template": "debian-7-x86_64",
+    "lifetime": 2,
+    "running": 0.08,
+    "state": "running",
+    "disk": [
+      "+8gb"
+    ],
+    "domain": "delivery.puppetlabs.net"
+  }
+}
+
+````
+
 #### VM snapshots
 
 ##### POST /vm/&lt;hostname&gt;/snapshot

--- a/lib/vmpooler/api/reroute.rb
+++ b/lib/vmpooler/api/reroute.rb
@@ -62,6 +62,10 @@ module Vmpooler
     post '/vm/:hostname/snapshot/:snapshot/?' do
       call env.merge("PATH_INFO" => "/api/v#{api_version}/vm/#{params[:hostname]}/snapshot/#{params[:snapshot]}")
     end
+
+    put '/vm/:hostname/disk/:size/?' do
+      call env.merge("PATH_INFO" => "/api/v#{api_version}/vm/#{params[:hostname]}/disk/#{params[:size]}")
+    end
   end
   end
 end

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -2,6 +2,10 @@ require 'rubygems' unless defined?(Gem)
 
 module Vmpooler
   class VsphereHelper
+    ADAPTER_TYPE = 'lsiLogic'
+    DISK_TYPE = 'thin'
+    DISK_MODE = 'persistent'
+
     def initialize(_vInfo = {})
       config_file = File.expand_path('vmpooler.yaml')
       vsphere = YAML.load_file(config_file)[:vsphere]
@@ -10,6 +14,60 @@ module Vmpooler
                                          user: vsphere['username'],
                                          password: vsphere['password'],
                                          insecure: true
+    end
+
+    def add_disk(vm, size, datastore)
+      begin
+        @connection.serviceInstance.CurrentTime
+      rescue
+        initialize
+      end
+
+      return false unless size.to_i > 0
+
+      vmdk_datastore = find_datastore(datastore)
+      vmdk_file_name = "#{vm['name']}/#{vm['name']}_#{find_vmdks(vm['name'], datastore).length + 1}.vmdk"
+
+      controller = find_disk_controller(vm)
+
+      vmdk_spec = RbVmomi::VIM::FileBackedVirtualDiskSpec(
+        capacityKb: size.to_i * 1024 * 1024,
+        adapterType: ADAPTER_TYPE,
+        diskType: DISK_TYPE
+      )
+
+      vmdk_backing = RbVmomi::VIM::VirtualDiskFlatVer2BackingInfo(
+        datastore: vmdk_datastore,
+        diskMode: DISK_MODE,
+        fileName: "[#{vmdk_datastore.name}] #{vmdk_file_name}"
+      )
+
+      device = RbVmomi::VIM::VirtualDisk(
+        backing: vmdk_backing,
+        capacityInKB: size.to_i * 1024 * 1024,
+        controllerKey: controller.key,
+        key: -1,
+        unitNumber: find_disk_unit_number(vm, controller)
+      )
+
+      device_config_spec = RbVmomi::VIM::VirtualDeviceConfigSpec(
+        device: device,
+        operation: RbVmomi::VIM::VirtualDeviceConfigSpecOperation('add')
+      )
+
+      vm_config_spec = RbVmomi::VIM::VirtualMachineConfigSpec(
+        deviceChange: [device_config_spec]
+      )
+
+      @connection.serviceContent.virtualDiskManager.CreateVirtualDisk_Task(
+        datacenter: @connection.serviceInstance.find_datacenter,
+        name: "[#{vmdk_datastore.name}] #{vmdk_file_name}",
+        spec: vmdk_spec
+      ).wait_for_completion
+
+      vm.ReconfigVM_Task(spec: vm_config_spec).wait_for_completion
+
+      true
     end
 
     def find_datastore(datastorename)
@@ -21,6 +79,99 @@ module Vmpooler
 
       datacenter = @connection.serviceInstance.find_datacenter
       datacenter.find_datastore(datastorename)
+    end
+
+    def find_device(vm, deviceName)
+      begin
+        @connection.serviceInstance.CurrentTime
+      rescue
+        initialize
+      end
+
+      vm.config.hardware.device.each do |device|
+        return device if device.deviceInfo.label == deviceName
+      end
+
+      nil
+    end
+
+    def find_disk_controller(vm)
+      begin
+        @connection.serviceInstance.CurrentTime
+      rescue
+        initialize
+      end
+
+      devices = find_disk_devices(vm)
+
+      devices.keys.sort.each do |device|
+        if devices[device]['children'].length < 15
+          return find_device(vm, devices[device]['device'].deviceInfo.label)
+        end
+      end
+
+      nil
+    end
+
+    def find_disk_devices(vm)
+      begin
+        @connection.serviceInstance.CurrentTime
+      rescue
+        initialize
+      end
+
+      devices = {}
+
+      vm.config.hardware.device.each do |device|
+        if device.is_a? RbVmomi::VIM::VirtualSCSIController
+          if devices[device.controllerKey].nil?
+            devices[device.key] = {}
+            devices[device.key]['children'] = []
+          end
+
+          devices[device.key]['device'] = device
+        end
+
+        if device.is_a? RbVmomi::VIM::VirtualDisk
+          if devices[device.controllerKey].nil?
+            devices[device.controllerKey] = {}
+            devices[device.controllerKey]['children'] = []
+          end
+
+          devices[device.controllerKey]['children'].push(device)
+        end
+      end
+
+      devices
+    end
+
+    def find_disk_unit_number(vm, controller)
+      begin
+        @connection.serviceInstance.CurrentTime
+      rescue
+        initialize
+      end
+
+      used_unit_numbers = []
+      available_unit_numbers = []
+
+      devices = find_disk_devices(vm)
+
+      devices.keys.sort.each do |c|
+        next unless controller.key == devices[c]['device'].key
+        used_unit_numbers.push(devices[c]['device'].scsiCtlrUnitNumber)
+        devices[c]['children'].each do |disk|
+          used_unit_numbers.push(disk.unitNumber)
+        end
+      end
+
+      (0..15).each do |scsi_id|
+        if used_unit_numbers.grep(scsi_id).length <= 0
+          available_unit_numbers.push(scsi_id)
+        end
+      end
+
+      available_unit_numbers.sort[0]
     end
 
     def find_folder(foldername)
@@ -167,6 +318,29 @@ module Vmpooler
       end
 
       vms
+    end
+
+    def find_vmdks(vmname, datastore)
+      begin
+        connection.serviceInstance.CurrentTime
+      rescue
+        initialize
+      end
+
+      disks = []
+
+      vmdk_datastore = find_datastore(datastore)
+
+      vm_files = vmdk_datastore._connection.serviceContent.propertyCollector.collectMultiple vmdk_datastore.vm, 'layoutEx.file'
+      vm_files.keys.each do |f|
+        vm_files[f]['layoutEx.file'].each do |l|
+          if l.name.match(/^\[#{vmdk_datastore.name}\] #{vmname}\/#{vmname}_([0-9]+).vmdk/)
+            disks.push(l)
+          end
+        end
+      end
+
+      disks
     end
 
     def get_base_vm_container_from(connection)


### PR DESCRIPTION
Add an additional disk to a running VM via the vmpooler API.

````
$ curl -X POST -H X-AUTH-TOKEN:a9znth9dn01t416hrguu56ze37t790bl \
  --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6/disk/8
````
````json
{
  "ok": true,
  "fq6qlpjlsskycq6": {
    "disk": "+8mb"
  }
}
````

Provisioning and attaching disks can take a moment, but once the task completes it will be reflected in a `GET /v1/vm/<hostname>` query:

````
$ curl --url vmpooler.company.com/api/v1/vm/fq6qlpjlsskycq6
````
````json
{
  "ok": true,
  "fq6qlpjlsskycq6": {
    "template": "debian-7-x86_64",
    "lifetime": 2,
    "running": 0.08,
    "state": "running",
    "disk": [
      "+8mb"
    ],
    "domain": "delivery.puppetlabs.net"
  }
}