### PR TITLE
Added prefix parameter to the vmpooler configuration

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -32,6 +32,7 @@ module Vmpooler
     parsed_config[:config]['task_limit']   ||= 10
     parsed_config[:config]['vm_checktime'] ||= 15
     parsed_config[:config]['vm_lifetime']  ||= 24
+    parsed_config[:config]['prefix']       ||= ''
 
     # Create an index of pool aliases
     parsed_config[:pools].each do |pool|

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -189,7 +189,7 @@ module Vmpooler
 
         # Generate a randomized hostname
         o = [('a'..'z'), ('0'..'9')].map(&:to_a).flatten
-        vm['hostname'] = o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
+        vm['hostname'] = $config[:config]['prefix'] + o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
 
         # Add VM to Redis inventory ('pending' pool)
         $redis.sadd('vmpooler__pending__' + vm['template'], vm['hostname'])

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -163,7 +163,9 @@
 #     If set, returns a top-level 'domain' JSON key in POST requests
 #
 #   - prefix
-#     If set, prefixes all created VMs with this string.
+#     If set, prefixes all created VMs with this string.  This should include
+#     a separator.
+#     (optional; default: '')
 
 # Example:
 
@@ -179,7 +181,7 @@
     - 'created_by'
     - 'project'
   domain: 'company.com'
-  prefix: ''
+  prefix: 'poolvm-'
 
 # :pools:
 #

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -161,6 +161,9 @@
 #
 #   - domain
 #     If set, returns a top-level 'domain' JSON key in POST requests
+#
+#   - prefix
+#     If set, prefixes all created VMs with this string.
 
 # Example:
 
@@ -176,6 +179,7 @@
     - 'created_by'
     - 'project'
   domain: 'company.com'
+  prefix: ''
 
 # :pools:
 #


### PR DESCRIPTION
I've found it useful to be able to specify a prefix to all created VMs.  This can help with defining autosign policy for puppet ("sign $prefix-<random string>") as well as VM organization.  This adds an optional parameter that lets the user do exactly this.