### PR TITLE
[QENG-3919] Make vmpooler checkouts be all or nothing

### DIFF
--- a/API.md
+++ b/API.md
@@ -117,6 +117,8 @@ $ curl -d '{"debian-7-i386":"2","debian-7-x86_64":"1"}' --url vmpooler.company.c
 }
 ```
 
+**NOTE: Returns either all requested VMs or no VMs.**
+
 ##### POST /vm/&lt;pool&gt;
 
 Check-out a VM or VMs.
@@ -155,6 +157,8 @@ $ curl -d --url vmpooler.company.com/api/v1/vm/debian-7-i386+debian-7-i386+debia
   "domain": "company.com"
 }
 ```
+
+**NOTE: Returns either all requested VMs or no VMs.**
 
 ##### GET /vm/&lt;hostname&gt;
 

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
 gem 'redis', '>= 3.2'
 gem 'sinatra', '>= 1.4'
+gem 'net-ldap', '>= 0.11'
 
 # Test deps
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
 gem 'redis', '>= 3.2'
 gem 'sinatra', '>= 1.4'
-gem 'net-ldap', '>= 0.11'
+gem 'net-ldap', '= 0.11'
 
 # Test deps
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
 gem 'redis', '>= 3.2'
 gem 'sinatra', '>= 1.4'
-gem 'net-ldap', '= 0.11'
+gem 'net-ldap', '<= 0.12.1' # keep compatibility w/ jruby & mri-1.9.3
 
 # Test deps
 group :test do

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -72,18 +72,6 @@ module Vmpooler
       end
     end
 
-    def checkout_vm(template, result)
-      if vm = fetch_single_vm(template)
-        account_for_starting_vm(template, vm)
-        update_result_hosts(result, template, vm)
-      else
-        status 503
-        result['ok'] = false
-      end
-
-      result
-    end
-
     def update_result_hosts(result, template, vm)
       result[template] ||= {}
       if result[template]['hostname']

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -50,7 +50,7 @@ module Vmpooler
     end
 
     def return_single_vm(template, vm)
-      backend.spush('vmpooler__ready__' + template, vm)
+      backend.sadd('vmpooler__ready__' + template, vm)
     end
 
     def account_for_starting_vm(template, vm)

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -104,6 +104,7 @@ module Vmpooler
       if failed
         vms.each do |(template, vm)|
           return_single_vm(template, vm)
+          status 503
         end
       else
         vms.each do |(template, vm)|

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -49,7 +49,7 @@ module Vmpooler
       backend.spop('vmpooler__ready__' + template)
     end
 
-    def return_single_vm(template, vm)
+    def return_vm_to_ready_state(template, vm)
       backend.sadd('vmpooler__ready__' + template, vm)
     end
 
@@ -103,7 +103,7 @@ module Vmpooler
 
       if failed
         vms.each do |(template, vm)|
-          return_single_vm(template, vm)
+          return_vm_to_ready_state(template, vm)
           status 503
         end
       else

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -348,7 +348,7 @@ module Vmpooler
         vms = []
 
         jdata.each do |template, count|
-          val.to_i.times do |_i|
+          count.to_i.times do |_i|
             vm = fetch_single_vm(template)
             if !vm
               failed = true
@@ -366,7 +366,7 @@ module Vmpooler
         else
           vms.each do |(template, vm)|
             account_for_starting_vm(template, vm)
-            update_result_hosts(results, template, vm)
+            update_result_hosts(result, template, vm)
           end
 
           result['ok'] = true

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -86,6 +86,16 @@ module Vmpooler
       result
     end
 
+    def update_result_hosts(result, template, vm)
+      result[template] ||= {}
+      if result[template]['hostname']
+        result[template]['hostname'] = Array(result[template]['hostname'])
+        result[template]['hostname'].push(vm)
+      else
+        result[template]['hostname'] = vm
+      end
+    end
+
     get "#{api_prefix}/status/?" do
       content_type :json
 
@@ -377,16 +387,6 @@ module Vmpooler
       end
 
       JSON.pretty_generate(result)
-    end
-
-    def update_result_hosts(result, template, vm)
-      result[template] ||= {}
-      if result[template]['hostname']
-        result[template]['hostname'] = Array(result[template]['hostname'])
-        result[template]['hostname'].push(vm)
-      else
-        result[template]['hostname'] = vm
-      end
     end
 
     post "#{api_prefix}/vm/:template/?" do

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -73,9 +73,7 @@ module Vmpooler
     end
 
     def checkout_vm(template, result)
-      vm = fetch_single_vm(template)
-
-      unless vm.nil?
+      if vm = fetch_single_vm(template)
         account_for_starting_vm(template, vm)
         update_result_hosts(result, template, vm)
       else

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -45,35 +45,39 @@ module Vmpooler
       newhash
     end
 
+    def fetch_single_vm(template)
+      backend.spop('vmpooler__ready__' + template)
+    end
+
+    def return_single_vm(template, vm)
+      backend.spush('vmpooler__ready__' + template, vm)
+    end
+
+    def account_for_starting_vm(template, vm)
+      backend.sadd('vmpooler__running__' + template, vm)
+      backend.hset('vmpooler__active__' + template, vm, Time.now)
+      backend.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
+
+      if Vmpooler::API.settings.config[:auth] and has_token?
+        validate_token(backend)
+
+        backend.hset('vmpooler__vm__' + vm, 'token:token', request.env['HTTP_X_AUTH_TOKEN'])
+        backend.hset('vmpooler__vm__' + vm, 'token:user',
+          backend.hget('vmpooler__token__' + request.env['HTTP_X_AUTH_TOKEN'], 'user')
+        )
+
+        if config['vm_lifetime_auth'].to_i > 0
+          backend.hset('vmpooler__vm__' + vm, 'lifetime', config['vm_lifetime_auth'].to_i)
+        end
+      end
+    end
+
     def checkout_vm(template, result)
-      vm = backend.spop('vmpooler__ready__' + template)
+      vm = fetch_single_vm(template)
 
       unless vm.nil?
-        backend.sadd('vmpooler__running__' + template, vm)
-        backend.hset('vmpooler__active__' + template, vm, Time.now)
-        backend.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
-
-        if Vmpooler::API.settings.config[:auth] and has_token?
-          validate_token(backend)
-
-          backend.hset('vmpooler__vm__' + vm, 'token:token', request.env['HTTP_X_AUTH_TOKEN'])
-          backend.hset('vmpooler__vm__' + vm, 'token:user',
-            backend.hget('vmpooler__token__' + request.env['HTTP_X_AUTH_TOKEN'], 'user')
-          )
-
-          if config['vm_lifetime_auth'].to_i > 0
-            backend.hset('vmpooler__vm__' + vm, 'lifetime', config['vm_lifetime_auth'].to_i)
-          end
-        end
-
-        result[template] ||= {}
-
-        if result[template]['hostname']
-          result[template]['hostname'] = [result[template]['hostname']] unless result[template]['hostname'].is_a?(Array)
-          result[template]['hostname'].push(vm)
-        else
-          result[template]['hostname'] = vm
-        end
+        account_for_starting_vm(template, vm)
+        update_result_hosts(result, template, vm)
       else
         status 503
         result['ok'] = false
@@ -335,38 +339,54 @@ module Vmpooler
 
     post "#{api_prefix}/vm/?" do
       content_type :json
-
       result = { 'ok' => false }
 
       jdata = alias_deref(JSON.parse(request.body.read))
 
       if not jdata.nil? and not jdata.empty?
-        available = 1
+        failed = false
+        vms = []
+
+        jdata.each do |template, count|
+          val.to_i.times do |_i|
+            vm = fetch_single_vm(template)
+            if !vm
+              failed = true
+              break
+            else
+              vms << [ template, vm ]
+            end
+          end
+        end
+
+        if failed
+          vms.each do |(template, vm)|
+            return_single_vm(template, vm)
+          end
+        else
+          vms.each do |(template, vm)|
+            account_for_starting_vm(template, vm)
+            update_result_hosts(results, template, vm)
+          end
+
+          result['ok'] = true
+          result['domain'] = config['domain'] if config['domain']
+        end
       else
         status 404
       end
 
-      jdata.each do |key, val|
-        if backend.scard('vmpooler__ready__' + key).to_i < val.to_i
-          available = 0
-        end
-      end
-
-      if (available == 1)
-        result['ok'] = true
-
-        jdata.each do |key, val|
-          val.to_i.times do |_i|
-            result = checkout_vm(key, result)
-          end
-        end
-      end
-
-      if result['ok'] && config['domain']
-        result['domain'] = config['domain']
-      end
-
       JSON.pretty_generate(result)
+    end
+
+    def update_result_hosts(result, template, vm)
+      result[template] ||= {}
+      if result[template]['hostname']
+        result[template]['hostname'] = Array(result[template]['hostname'])
+        result[template]['hostname'].push(vm)
+      else
+        result[template]['hostname'] = vm
+      end
     end
 
     post "#{api_prefix}/vm/:template/?" do

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -311,7 +311,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
@@ -324,7 +324,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -337,7 +337,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -350,7 +350,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -363,7 +363,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -376,7 +376,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       context '(auth not configured)' do
@@ -577,7 +577,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
@@ -590,7 +590,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -603,7 +603,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -616,7 +616,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -629,7 +629,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -642,7 +642,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200) # which HTTP status code?
+        expect_json(ok = false, http = 200)
       end
 
       context '(auth not configured)' do

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -239,7 +239,7 @@ describe Vmpooler::API::V1 do
         expect_json(ok = true, http = 200)
       end
 
-      it 'fails on nonexistant pools' do
+      it 'fails on nonexistent pools' do
         expect(redis).to receive(:exists).with("vmpooler__ready__poolpoolpool").and_return(false)
 
         post "#{prefix}/vm", '{"poolpoolpool":"1"}'
@@ -505,7 +505,7 @@ describe Vmpooler::API::V1 do
         expect_json(ok = true, http = 200)
       end
 
-      it 'fails on nonexistant pools' do
+      it 'fails on nonexistent pools' do
         expect(redis).to receive(:exists).with("vmpooler__ready__poolpoolpool").and_return(false)
 
         post "#{prefix}/vm/poolpoolpool", ''

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -311,7 +311,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
@@ -324,7 +324,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -337,7 +337,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -350,7 +350,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -363,7 +363,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -376,7 +376,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       context '(auth not configured)' do
@@ -577,7 +577,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
@@ -590,7 +590,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -603,7 +603,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
@@ -616,7 +616,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -629,7 +629,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
@@ -642,7 +642,7 @@ describe Vmpooler::API::V1 do
         expected = { ok: false }
 
         expect(last_response.body).to eq(JSON.pretty_generate(expected))
-        expect_json(ok = false, http = 200)
+        expect_json(ok = false, http = 503)
       end
 
       context '(auth not configured)' do

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -304,7 +304,7 @@ describe Vmpooler::API::V1 do
       it 'fails when not all requested vms can be allocated' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        allow(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm", '{"pool1":"1","pool2":"1"}'
 
@@ -317,7 +317,7 @@ describe Vmpooler::API::V1 do
       it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        expect(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm", '{"pool1":"1","pool2":"1"}'
 
@@ -330,7 +330,7 @@ describe Vmpooler::API::V1 do
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        allow(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm", '{"pool1":"2","pool2":"1"}'
 
@@ -343,7 +343,7 @@ describe Vmpooler::API::V1 do
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
+        expect(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
 
         post "#{prefix}/vm", '{"pool1":"2","pool2":"1"}'
 
@@ -356,7 +356,7 @@ describe Vmpooler::API::V1 do
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        allow(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm", '{"pool1":"2","pool2":"3"}'
 
@@ -369,7 +369,7 @@ describe Vmpooler::API::V1 do
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
+        expect(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
 
         post "#{prefix}/vm", '{"pool1":"2","pool2":"3"}'
 
@@ -570,7 +570,7 @@ describe Vmpooler::API::V1 do
       it 'fails when not all requested vms can be allocated' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        allow(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm/pool1+pool2", ''
 
@@ -583,7 +583,7 @@ describe Vmpooler::API::V1 do
       it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        expect(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm/pool1+pool2", ''
 
@@ -596,7 +596,7 @@ describe Vmpooler::API::V1 do
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        allow(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm/pool1+pool1+pool2", ''
 
@@ -609,7 +609,7 @@ describe Vmpooler::API::V1 do
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
+        expect(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
 
         post "#{prefix}/vm/pool1+pool1+pool2", ''
 
@@ -622,7 +622,7 @@ describe Vmpooler::API::V1 do
       it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+        allow(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm/pool1+pool1+pool2+pool2+pool2", ''
 
@@ -635,7 +635,7 @@ describe Vmpooler::API::V1 do
       it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
-        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
+        expect(redis).to receive(:sadd).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
 
         post "#{prefix}/vm/pool1+pool1+pool2+pool2+pool2", ''
 

--- a/spec/vmpooler/api/v1_spec.rb
+++ b/spec/vmpooler/api/v1_spec.rb
@@ -265,6 +265,42 @@ describe Vmpooler::API::V1 do
         expect_json(ok = true, http = 200)
       end
 
+      it 'returns multiple VMs even when multiple instances from the same pool are requested' do
+        post "#{prefix}/vm", '{"pool1":"2","pool2":"1"}'
+
+        expected = {
+          ok: true,
+          pool1: {
+            hostname: [ 'abcdefghijklmnop', 'abcdefghijklmnop' ]
+          },
+          pool2: {
+            hostname: 'qrstuvwxyz012345'
+          }
+        }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+        expect_json(ok = true, http = 200)
+      end
+
+      it 'returns multiple VMs even when multiple instances from multiple pools are requested' do
+        post "#{prefix}/vm", '{"pool1":"2","pool2":"3"}'
+
+        expected = {
+          ok: true,
+          pool1: {
+            hostname: [ 'abcdefghijklmnop', 'abcdefghijklmnop' ]
+          },
+          pool2: {
+            hostname: [ 'qrstuvwxyz012345', 'qrstuvwxyz012345', 'qrstuvwxyz012345' ]
+          }
+        }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+
+        expect_json(ok = true, http = 200)
+      end
+
       it 'fails when not all requested vms can be allocated' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
@@ -278,12 +314,64 @@ describe Vmpooler::API::V1 do
         expect_json(ok = false, http = 200) # which HTTP status code?
       end
 
-      it 'returns any checked out vms when not all requested vms can be allocated' do
+      it 'returns any checked out vms to their pools when not all requested vms can be allocated' do
         allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
         allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
         expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
 
         post "#{prefix}/vm", '{"pool1":"1","pool2":"1"}'
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+        expect_json(ok = false, http = 200) # which HTTP status code?
+      end
+
+      it 'fails when not all requested vms can be allocated, when requesting multiple instances from a pool' do
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
+        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+
+        post "#{prefix}/vm", '{"pool1":"2","pool2":"1"}'
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+        expect_json(ok = false, http = 200) # which HTTP status code?
+      end
+
+      it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from a pool' do
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
+        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
+
+        post "#{prefix}/vm", '{"pool1":"2","pool2":"1"}'
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+        expect_json(ok = false, http = 200) # which HTTP status code?
+      end
+
+      it 'fails when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
+        allow(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop")
+
+        post "#{prefix}/vm", '{"pool1":"2","pool2":"3"}'
+
+        expected = { ok: false }
+
+        expect(last_response.body).to eq(JSON.pretty_generate(expected))
+        expect_json(ok = false, http = 200) # which HTTP status code?
+      end
+
+      it 'returns any checked out vms to their pools when not all requested vms can be allocated, when requesting multiple instances from multiple pools' do
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool1').and_return 'abcdefghijklmnop'
+        allow(redis).to receive(:spop).with('vmpooler__ready__pool2').and_return nil
+        expect(redis).to receive(:spush).with("vmpooler__ready__pool1", "abcdefghijklmnop").exactly(2).times
+
+        post "#{prefix}/vm", '{"pool1":"2","pool2":"3"}'
 
         expected = { ok: false }
 


### PR DESCRIPTION
![](https://upload.wikimedia.org/wikipedia/en/d/de/Jay_Sean_-_All_or_Nothing.jpg)

Prior to this, vmpooler could partially fill requests for multiple VMs. Here we move to an algorithm that returns the entire set of requested VMs or no VMs.

/cc @puppetlabs/cinext 