### PR TITLE
Added IP lookup functionality for /vm/hostname

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -459,6 +459,15 @@ module Vmpooler
           result[params[:hostname]]['disk'] = rdata['disk'].split(':')
         end
 
+        # Look up IP address of the hostname
+        begin
+          ipAddress = TCPSocket.gethostbyname(params[:hostname])[3]
+        rescue
+          ipAddress = ""
+        end
+
+        result[params[:hostname]]['ip'] = ipAddress
+
         if config['domain']
           result[params[:hostname]]['domain'] = config['domain']
         end


### PR DESCRIPTION
I've discovered a need to see the IP of a vm from vmpooler when querying the status of a vm.  This code utilizes the same TCPSocket functionality found elsewhere in the codebase to retrieve the IP from vmpooler's perspective.  This information is localized to returning information about a vm since this is where all the other in-depth information about a vm is contained and only adds to the data, does not modify existing data.  This should means that scripts and workflows currently against vmpooler shouldn't need modification to continue functioning.