### PR TITLE
(maint) update README.md and LICENSE to reflect rebranding

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
    vmpooler
 
-   Copyright (C) 2013-2016 Puppet Labs
+   Copyright (C) 2013-2016 Puppet
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ vmpooler provides configurable 'pools' of instantly-available (running) virtual 
 
 ## Usage
 
-At [Puppet Labs](http://puppetlabs.com) we run acceptance tests on thousands of disposable VMs every day.  Dynamic cloning of VM templates initially worked fine for this, but added several seconds to each test run and was unable to account for failed clone tasks.  By pushing these operations to a backend service, we were able to both speed up tests and eliminate test failures due to underlying infrastructure failures.
+At [Puppet](http://puppet.com) we run acceptance tests on thousands of disposable VMs every day.  Dynamic cloning of VM templates initially worked fine for this, but added several seconds to each test run and was unable to account for failed clone tasks.  By pushing these operations to a backend service, we were able to both speed up tests and eliminate test failures due to underlying infrastructure failures.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ vmpooler provides configurable 'pools' of instantly-available (running) virtual 
 
 ## Usage
 
-At [Puppet](http://puppet.com) we run acceptance tests on thousands of disposable VMs every day.  Dynamic cloning of VM templates initially worked fine for this, but added several seconds to each test run and was unable to account for failed clone tasks.  By pushing these operations to a backend service, we were able to both speed up tests and eliminate test failures due to underlying infrastructure failures.
+At [Puppet, Inc.](http://puppet.com) we run acceptance tests on thousands of disposable VMs every day.  Dynamic cloning of VM templates initially worked fine for this, but added several seconds to each test run and was unable to account for failed clone tasks.  By pushing these operations to a backend service, we were able to both speed up tests and eliminate test failures due to underlying infrastructure failures.
 
 
 ## Installation


### PR DESCRIPTION
Prior to this commit, the README and LICENSE referenced Puppet Labs.

This commit updates those files to drop the "Labs" from these
references.