### PR TITLE
(QENG-3376) Allow lifetime to be set per-pool

### DIFF
--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -36,7 +36,7 @@ def create_ready_vm(template, name, token = nil)
   create_vm(name, token)
   redis.sadd("vmpooler__ready__#{template}", name)
   # REMIND: should be __vm__?
-  redis.hset("vmpooler_vm_#{name}", "template", template)
+  redis.hset("vmpooler__vm__#{name}", "template", template)
 end
 
 def create_running_vm(template, name, token = nil)

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -285,6 +285,14 @@
 #   - ready_ttl
 #     How long (in minutes) to keep VMs in 'ready' queues before destroying.
 #     (optional)
+#
+#   - vm_lifetime
+#     How long (in hours) to keep VMs in 'running' queues before destroying.
+#     (optional; default: '24')
+#
+#   - vm_lifetime_auth
+#     Same as vm_lifetime, but applied if a valid authentication token is
+#     included during the request.
 
 # Example:
 
@@ -305,3 +313,5 @@
     size: 5
     timeout: 15
     ready_ttl: 1440
+    vm_lifetime: 1
+    vm_lifetime_auth: 4


### PR DESCRIPTION
At current vm_lifetime and vm_lifetime_auth are configured globally only.  This change allows that value to be set/overridden per pool.