### PR TITLE
Improve vmpooler scheduling logic

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'statsd-ruby', '>= 1.3.0', :require => 'statsd'
 
 # Test deps
 group :test do
+  gem 'mock_redis', '>= 0.17.0'
   gem 'rack-test', '>= 0.6'
   gem 'rspec', '>= 3.2'
   gem 'simplecov', '>= 0.11.2'

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -55,6 +55,7 @@ module Vmpooler
 
     def account_for_starting_vm(template, vm)
       backend.sadd('vmpooler__running__' + template, vm)
+      backend.sadd('vmpooler__migrating__' + template, vm)
       backend.hset('vmpooler__active__' + template, vm, Time.now)
       backend.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
 

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -20,9 +20,9 @@ module Vmpooler
     end
 
     # Check the state of a VM
-    def check_pending_vm(vm, pool, timeout)
+    def check_pending_vm(vm, pool, timeout, vsphere)
       Thread.new do
-        _check_pending_vm(vm, pool, timeout)
+        _check_pending_vm(vm, pool, timeout, vsphere)
       end
     end
 
@@ -34,12 +34,14 @@ module Vmpooler
       end
     end
 
-    def _check_pending_vm(vm, pool, timeout)
-      host = $vsphere[pool].find_vm(vm)
+    def _check_pending_vm(vm, pool, timeout, vsphere)
+      host = vsphere.find_vm(vm)
 
       if host
         begin
-          open_socket vm, $config[:config]['domain'], timeout
+          Timeout.timeout(5) do
+            TCPSocket.new vm, 22
+          end
           move_pending_vm_to_ready(vm, pool, host)
         rescue
           fail_pending_vm(vm, pool, timeout)
@@ -87,7 +89,7 @@ module Vmpooler
       end
     end
 
-    def check_ready_vm(vm, pool, ttl)
+    def check_ready_vm(vm, pool, ttl, vsphere)
       Thread.new do
         if ttl > 0
           if (((Time.now - host.runtime.bootTime) / 60).to_s[/^\d+\.\d{1}/].to_f) > ttl
@@ -105,8 +107,8 @@ module Vmpooler
 
           $redis.hset('vmpooler__vm__' + vm, 'check', Time.now)
 
-          host = $vsphere[pool].find_vm(vm) ||
-                 $vsphere[pool].find_vm_heavy(vm)[vm]
+          host = vsphere.find_vm(vm) ||
+                 vsphere.find_vm_heavy(vm)[vm]
 
           if host
             if
@@ -147,14 +149,14 @@ module Vmpooler
       end
     end
 
-    def check_running_vm(vm, pool, ttl)
+    def check_running_vm(vm, pool, ttl, vsphere)
       Thread.new do
-        _check_running_vm(vm, pool, ttl)
+        _check_running_vm(vm, pool, ttl, vsphere)
       end
     end
 
-    def _check_running_vm(vm, pool, ttl)
-      host = $vsphere[pool].find_vm(vm)
+    def _check_running_vm(vm, pool, ttl, vsphere)
+      host = vsphere.find_vm(vm)
 
       if host
         queue_from, queue_to = 'running', 'completed'
@@ -178,101 +180,105 @@ module Vmpooler
     end
 
     # Clone a VM
-    def clone_vm(template, folder, datastore, target)
+    def clone_vm(template, folder, datastore, target, vsphere)
       Thread.new do
-        vm = {}
-
-        if template =~ /\//
-          templatefolders = template.split('/')
-          vm['template'] = templatefolders.pop
-        end
-
-        if templatefolders
-          vm[vm['template']] = $vsphere[vm['template']].find_folder(templatefolders.join('/')).find(vm['template'])
-        else
-          fail 'Please provide a full path to the template'
-        end
-
-        if vm['template'].length == 0
-          fail "Unable to find template '#{vm['template']}'!"
-        end
-
-        # Generate a randomized hostname
-        o = [('a'..'z'), ('0'..'9')].map(&:to_a).flatten
-        vm['hostname'] = $config[:config]['prefix'] + o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
-
-        # Add VM to Redis inventory ('pending' pool)
-        $redis.sadd('vmpooler__pending__' + vm['template'], vm['hostname'])
-        $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone', Time.now)
-        $redis.hset('vmpooler__vm__' + vm['hostname'], 'template', vm['template'])
-
-        # Annotate with creation time, origin template, etc.
-        # Add extraconfig options that can be queried by vmtools
-        configSpec = RbVmomi::VIM.VirtualMachineConfigSpec(
-          annotation: JSON.pretty_generate(
-              name: vm['hostname'],
-              created_by: $config[:vsphere]['username'],
-              base_template: vm['template'],
-              creation_timestamp: Time.now.utc
-          ),
-          extraConfig: [
-              { key: 'guestinfo.hostname',
-                value: vm['hostname']
-              }
-          ]
-        )
-
-        # Choose a clone target
-        if target
-          $clone_target = $vsphere[vm['template']].find_least_used_host(target)
-        elsif $config[:config]['clone_target']
-          $clone_target = $vsphere[vm['template']].find_least_used_host($config[:config]['clone_target'])
-        end
-
-        # Put the VM in the specified folder and resource pool
-        relocateSpec = RbVmomi::VIM.VirtualMachineRelocateSpec(
-          datastore: $vsphere[vm['template']].find_datastore(datastore),
-          host: $clone_target,
-          diskMoveType: :moveChildMostDiskBacking
-        )
-
-        # Create a clone spec
-        spec = RbVmomi::VIM.VirtualMachineCloneSpec(
-          location: relocateSpec,
-          config: configSpec,
-          powerOn: true,
-          template: false
-        )
-
-        # Clone the VM
-        $logger.log('d', "[ ] [#{vm['template']}] '#{vm['hostname']}' is being cloned from '#{vm['template']}'")
-
         begin
-          start = Time.now
-          vm[vm['template']].CloneVM_Task(
-            folder: $vsphere[vm['template']].find_folder(folder),
-            name: vm['hostname'],
-            spec: spec
-          ).wait_for_completion
-          finish = '%.2f' % (Time.now - start)
+          vm = {}
 
-          $redis.hset('vmpooler__clone__' + Date.today.to_s, vm['template'] + ':' + vm['hostname'], finish)
-          $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone_time', finish)
+          if template =~ /\//
+            templatefolders = template.split('/')
+            vm['template'] = templatefolders.pop
+          end
 
-          $logger.log('s', "[+] [#{vm['template']}] '#{vm['hostname']}' cloned from '#{vm['template']}' in #{finish} seconds")
-        rescue
-          $logger.log('s', "[!] [#{vm['template']}] '#{vm['hostname']}' clone appears to have failed")
-          $redis.srem('vmpooler__pending__' + vm['template'], vm['hostname'])
+          if templatefolders
+            vm[vm['template']] = vsphere.find_folder(templatefolders.join('/')).find(vm['template'])
+          else
+            fail 'Please provide a full path to the template'
+          end
+
+          if vm['template'].length == 0
+            fail "Unable to find template '#{vm['template']}'!"
+          end
+
+          # Generate a randomized hostname
+          o = [('a'..'z'), ('0'..'9')].map(&:to_a).flatten
+          vm['hostname'] = $config[:config]['prefix'] + o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
+
+          # Add VM to Redis inventory ('pending' pool)
+          $redis.sadd('vmpooler__pending__' + vm['template'], vm['hostname'])
+          $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone', Time.now)
+          $redis.hset('vmpooler__vm__' + vm['hostname'], 'template', vm['template'])
+
+          # Annotate with creation time, origin template, etc.
+          # Add extraconfig options that can be queried by vmtools
+          configSpec = RbVmomi::VIM.VirtualMachineConfigSpec(
+            annotation: JSON.pretty_generate(
+                name: vm['hostname'],
+                created_by: $config[:vsphere]['username'],
+                base_template: vm['template'],
+                creation_timestamp: Time.now.utc
+            ),
+            extraConfig: [
+                { key: 'guestinfo.hostname',
+                  value: vm['hostname']
+                }
+            ]
+          )
+
+          # Choose a clone target
+          if target
+            $clone_target = vsphere.find_least_used_host(target)
+          elsif $config[:config]['clone_target']
+            $clone_target = vsphere.find_least_used_host($config[:config]['clone_target'])
+          end
+
+          # Put the VM in the specified folder and resource pool
+          relocateSpec = RbVmomi::VIM.VirtualMachineRelocateSpec(
+            datastore: vsphere.find_datastore(datastore),
+            host: $clone_target,
+            diskMoveType: :moveChildMostDiskBacking
+          )
+
+          # Create a clone spec
+          spec = RbVmomi::VIM.VirtualMachineCloneSpec(
+            location: relocateSpec,
+            config: configSpec,
+            powerOn: true,
+            template: false
+          )
+
+          # Clone the VM
+          $logger.log('d', "[ ] [#{vm['template']}] '#{vm['hostname']}' is being cloned from '#{vm['template']}'")
+
+          begin
+            start = Time.now
+            vm[vm['template']].CloneVM_Task(
+              folder: vsphere.find_folder(folder),
+              name: vm['hostname'],
+              spec: spec
+            ).wait_for_completion
+            finish = '%.2f' % (Time.now - start)
+
+            $redis.hset('vmpooler__clone__' + Date.today.to_s, vm['template'] + ':' + vm['hostname'], finish)
+            $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone_time', finish)
+
+            $logger.log('s', "[+] [#{vm['template']}] '#{vm['hostname']}' cloned from '#{vm['template']}' in #{finish} seconds")
+          rescue => err
+            $logger.log('s', "[!] [#{vm['template']}] '#{vm['hostname']}' clone failed with an error: #{err}")
+            $redis.srem('vmpooler__pending__' + vm['template'], vm['hostname'])
+          end
+
+          $redis.decr('vmpooler__tasks__clone')
+
+          $metrics.timing("clone.#{vm['template']}", finish)
+        rescue => err
+          $logger.log('s', "[!] [#{vm['template']}] '#{vm['hostname']}' failed while preparing to clone with an error: #{err}")
         end
-
-        $redis.decr('vmpooler__tasks__clone')
-
-        $metrics.timing("clone.#{vm['template']}", finish)
       end
     end
 
     # Destroy a VM
-    def destroy_vm(vm, pool)
+    def destroy_vm(vm, pool, vsphere)
       Thread.new do
         $redis.srem('vmpooler__completed__' + pool, vm)
         $redis.hdel('vmpooler__active__' + pool, vm)
@@ -281,8 +287,8 @@ module Vmpooler
         # Auto-expire metadata key
         $redis.expire('vmpooler__vm__' + vm, ($config[:redis]['data_ttl'].to_i * 60 * 60))
 
-        host = $vsphere[pool].find_vm(vm) ||
-               $vsphere[pool].find_vm_heavy(vm)[vm]
+        host = vsphere.find_vm(vm) ||
+               vsphere.find_vm_heavy(vm)[vm]
 
         if host
           start = Time.now
@@ -305,15 +311,15 @@ module Vmpooler
       end
     end
 
-    def create_vm_disk(vm, disk_size)
+    def create_vm_disk(vm, disk_size, vsphere)
       Thread.new do
-        _create_vm_disk(vm, disk_size)
+        _create_vm_disk(vm, disk_size, vsphere)
       end
     end
 
-    def _create_vm_disk(vm, disk_size)
-      host = $vsphere['disk_manager'].find_vm(vm) ||
-             $vsphere['disk_manager'].find_vm_heavy(vm)[vm]
+    def _create_vm_disk(vm, disk_size, vsphere)
+      host = vsphere.find_vm(vm) ||
+             vsphere.find_vm_heavy(vm)[vm]
 
       if (host) && ((! disk_size.nil?) && (! disk_size.empty?) && (disk_size.to_i > 0))
         $logger.log('s', "[ ] [disk_manager] '#{vm}' is attaching a #{disk_size}gb disk")
@@ -330,7 +336,7 @@ module Vmpooler
         end
 
         if ((! datastore.nil?) && (! datastore.empty?))
-          $vsphere['disk_manager'].add_disk(host, disk_size, datastore)
+          vsphere.add_disk(host, disk_size, datastore)
 
           rdisks = $redis.hget('vmpooler__vm__' + vm, 'disk')
           disks = rdisks ? rdisks.split(':') : []
@@ -346,15 +352,15 @@ module Vmpooler
       end
     end
 
-    def create_vm_snapshot(vm, snapshot_name)
+    def create_vm_snapshot(vm, snapshot_name, vsphere)
       Thread.new do
-        _create_vm_snapshot(vm, snapshot_name)
+        _create_vm_snapshot(vm, snapshot_name, vsphere)
       end
     end
 
-    def _create_vm_snapshot(vm, snapshot_name)
-      host = $vsphere['snapshot_manager'].find_vm(vm) ||
-             $vsphere['snapshot_manager'].find_vm_heavy(vm)[vm]
+    def _create_vm_snapshot(vm, snapshot_name, vsphere)
+      host = vsphere.find_vm(vm) ||
+             vsphere.find_vm_heavy(vm)[vm]
 
       if (host) && ((! snapshot_name.nil?) && (! snapshot_name.empty?))
         $logger.log('s', "[ ] [snapshot_manager] '#{vm}' is being snapshotted")
@@ -376,18 +382,18 @@ module Vmpooler
       end
     end
 
-    def revert_vm_snapshot(vm, snapshot_name)
+    def revert_vm_snapshot(vm, snapshot_name, vsphere)
       Thread.new do
-        _revert_vm_snapshot(vm, snapshot_name)
+        _revert_vm_snapshot(vm, snapshot_name, vsphere)
       end
     end
 
-    def _revert_vm_snapshot(vm, snapshot_name)
-      host = $vsphere['snapshot_manager'].find_vm(vm) ||
-             $vsphere['snapshot_manager'].find_vm_heavy(vm)[vm]
+    def _revert_vm_snapshot(vm, snapshot_name, vsphere)
+      host = vsphere.find_vm(vm) ||
+             vsphere.find_vm_heavy(vm)[vm]
 
       if host
-        snapshot = $vsphere['snapshot_manager'].find_snapshot(host, snapshot_name)
+        snapshot = vsphere.find_snapshot(host, snapshot_name)
 
         if snapshot
           $logger.log('s', "[ ] [snapshot_manager] '#{vm}' is being reverted to snapshot '#{snapshot_name}'")
@@ -410,19 +416,19 @@ module Vmpooler
 
       $threads['disk_manager'] = Thread.new do
         loop do
-          _check_disk_queue
+          _check_disk_queue $vsphere['disk_manager']
           sleep(5)
         end
       end
     end
 
-    def _check_disk_queue
+    def _check_disk_queue(vsphere)
       vm = $redis.spop('vmpooler__tasks__disk')
 
       unless vm.nil?
         begin
           vm_name, disk_size = vm.split(':')
-          create_vm_disk(vm_name, disk_size)
+          create_vm_disk(vm_name, disk_size, vsphere)
         rescue
           $logger.log('s', "[!] [disk_manager] disk creation appears to have failed")
         end
@@ -436,19 +442,19 @@ module Vmpooler
 
       $threads['snapshot_manager'] = Thread.new do
         loop do
-          _check_snapshot_queue
+          _check_snapshot_queue $vsphere['snapshot_manager']
           sleep(5)
         end
       end
     end
 
-    def _check_snapshot_queue
+    def _check_snapshot_queue(vsphere)
       vm = $redis.spop('vmpooler__tasks__snapshot')
 
       unless vm.nil?
         begin
           vm_name, snapshot_name = vm.split(':')
-          create_vm_snapshot(vm_name, snapshot_name)
+          create_vm_snapshot(vm_name, snapshot_name, vsphere)
         rescue
           $logger.log('s', "[!] [snapshot_manager] snapshot appears to have failed")
         end
@@ -459,15 +465,15 @@ module Vmpooler
       unless vm.nil?
         begin
           vm_name, snapshot_name = vm.split(':')
-          revert_vm_snapshot(vm_name, snapshot_name)
+          revert_vm_snapshot(vm_name, snapshot_name, vsphere)
         rescue
           $logger.log('s', "[!] [snapshot_manager] snapshot revert appears to have failed")
         end
       end
     end
 
-    def find_vsphere_pool_vm(pool, vm)
-      $vsphere[pool].find_vm(vm) || $vsphere[pool].find_vm_heavy(vm)[vm]
+    def find_vsphere_pool_vm(pool, vm, vsphere)
+      vsphere.find_vm(vm) || vsphere.find_vm_heavy(vm)[vm]
     end
 
     def migration_limit(migration_limit)
@@ -476,43 +482,65 @@ module Vmpooler
       migration_limit if migration_limit >= 1
     end
 
-    def migrate_vm(vm, pool)
+    def migrate_vm(vm, pool, vsphere)
       Thread.new do
-        _migrate_vm(vm, pool)
+        _migrate_vm(vm, pool, vsphere)
       end
     end
 
-    def _migrate_vm(vm, pool)
-      $redis.srem('vmpooler__migrating__' + pool, vm)
-      vm_object = find_vsphere_pool_vm(pool, vm)
-      parent_host = vm_object.summary.runtime.host
-      parent_host_name = parent_host.name
-      migration_limit = migration_limit $config[:config]['migration_limit']
+    def _migrate_vm(vm, pool, vsphere)
+      begin
+        $redis.srem('vmpooler__migrating__' + pool, vm)
+        vm_object = find_vsphere_pool_vm(pool, vm, vsphere)
+        parent_host, parent_host_name = get_vm_host_info(vm_object)
+        migration_limit = migration_limit $config[:config]['migration_limit']
 
-      if not migration_limit
-        $logger.log('s', "[ ] [#{pool}] '#{vm}' is running on #{parent_host_name}")
-      else
-        migration_count = $redis.smembers('vmpooler__migration').size
-        if migration_count >= migration_limit
-          $logger.log('s', "[ ] [#{pool}] '#{vm}' is running on #{parent_host_name}. No migration will be evaluated since the migration_limit has been reached")
+        if not migration_limit
+          $logger.log('s', "[ ] [#{pool}] '#{vm}' is running on #{parent_host_name}")
         else
-          $redis.sadd('vmpooler__migration', vm)
-          host = $vsphere[pool].find_least_used_compatible_host(vm_object)
-          if host == parent_host
-            $logger.log('s', "[ ] [#{pool}] No migration required for '#{vm}' running on #{parent_host_name}")
+          migration_count = $redis.smembers('vmpooler__migration').size
+          if migration_count >= migration_limit
+            $logger.log('s', "[ ] [#{pool}] '#{vm}' is running on #{parent_host_name}. No migration will be evaluated since the migration_limit has been reached")
           else
-            start = Time.now
-            $vsphere[pool].migrate_vm_host(vm_object, host)
-            finish = '%.2f' % (Time.now - start)
-            $metrics.timing("migrate.#{vm['template']}", finish)
-            checkout_to_migration = '%.2f' % (Time.now - Time.parse($redis.hget('vmpooler__vm__' + vm, 'checkout')))
-            $redis.hset('vmpooler__vm__' + vm, 'migration_time', finish)
-            $redis.hset('vmpooler__vm__' + vm, 'checkout_to_migration', checkout_to_migration)
-            $logger.log('s', "[>] [#{pool}] '#{vm}' migrated from #{parent_host_name} to #{host.name} in #{finish} seconds")
+            $redis.sadd('vmpooler__migration', vm)
+            host, host_name = vsphere.find_least_used_compatible_host(vm_object)
+            if host == parent_host
+              $logger.log('s', "[ ] [#{pool}] No migration required for '#{vm}' running on #{parent_host_name}")
+            else
+              finish = migrate_vm_and_record_timing(vm_object, vm, host, vsphere)
+              $logger.log('s', "[>] [#{pool}] '#{vm}' migrated from #{parent_host_name} to #{host_name} in #{finish} seconds")
+            end
+            remove_vmpooler_migration_vm(pool, vm)
           end
-          $redis.srem('vmpooler__migration', vm)
         end
+      rescue => err
+        $logger.log('s', "[x] [#{pool}] '#{vm}' migration failed with an error: #{err}")
+        remove_vmpooler_migration_vm(pool, vm)
       end
+    end
+
+    def get_vm_host_info(vm_object)
+      parent_host = vm_object.summary.runtime.host
+      [parent_host, parent_host.name]
+    end
+
+    def remove_vmpooler_migration_vm(pool, vm)
+      begin
+        $redis.srem('vmpooler__migration', vm)
+      rescue => err
+        $logger.log('s', "[x] [#{pool}] '#{vm}' removal from vmpooler__migration failed with an error: #{err}")
+      end
+    end
+
+    def migrate_vm_and_record_timing(vm_object, vm_name, host, vsphere)
+      start = Time.now
+      vsphere.migrate_vm_host(vm_object, host)
+      finish = '%.2f' % (Time.now - start)
+      $metrics.timing("migrate.#{vm_name}", finish)
+      checkout_to_migration = '%.2f' % (Time.now - Time.parse($redis.hget("vmpooler__vm__#{vm_name}", 'checkout')))
+      $redis.hset("vmpooler__vm__#{vm_name}", 'migration_time', finish)
+      $redis.hset("vmpooler__vm__#{vm_name}", 'checkout_to_migration', checkout_to_migration)
+      finish
     end
 
     def check_pool(pool)
@@ -522,17 +550,17 @@ module Vmpooler
 
       $threads[pool['name']] = Thread.new do
         loop do
-          _check_pool(pool)
+          _check_pool(pool, $vsphere[pool['name']])
           sleep(5)
         end
       end
     end
 
-    def _check_pool(pool)
+    def _check_pool(pool, vsphere)
       # INVENTORY
       inventory = {}
       begin
-        base = $vsphere[pool['name']].find_folder(pool['folder'])
+        base = vsphere.find_folder(pool['folder'])
 
         base.childEntity.each do |vm|
           if
@@ -554,111 +582,93 @@ module Vmpooler
       end
 
       # RUNNING
-      running = $redis.smembers("vmpooler__running__#{pool['name']}")
-      if running
-        running.each do |vm|
-          if inventory[vm]
-            begin
-              check_running_vm(vm, pool['name'], $redis.hget('vmpooler__vm__' + vm, 'lifetime') || $config[:config]['vm_lifetime'] || 12)
-            rescue
-            end
+      $redis.smembers("vmpooler__running__#{pool['name']}").each do |vm|
+        if inventory[vm]
+          begin
+            check_running_vm(vm, pool['name'], $redis.hget('vmpooler__vm__' + vm, 'lifetime') || $config[:config]['vm_lifetime'] || 12, vsphere)
+          rescue
           end
         end
       end
 
       # READY
-      ready = $redis.smembers("vmpooler__ready__#{pool['name']}")
-      if ready
-        ready.each do |vm| if ready
-          if inventory[vm]
-            begin
-              check_ready_vm(vm, pool['name'], pool['ready_ttl'] || 0)
-            rescue
-            end
+      $redis.smembers("vmpooler__ready__#{pool['name']}").each do |vm|
+        if inventory[vm]
+          begin
+            check_ready_vm(vm, pool['name'], pool['ready_ttl'] || 0, vsphere)
+          rescue
           end
         end
       end
 
       # PENDING
-      pending = $redis.smembers('vmpooler__pending__' + pool['name'])
-      if pending
-        pending.each do |vm|
-          if inventory[vm]
-            begin
-              check_pending_vm(vm, pool['name'], pool['timeout'] || $config[:config]['timeout'] || 15)
-            rescue
-            end
+      $redis.smembers("vmpooler__pending__#{pool['name']}").each do |vm|
+        if inventory[vm]
+          begin
+            check_pending_vm(vm, pool['name'], pool['timeout'] || $config[:config]['timeout'] || 15, vsphere)
+          rescue
           end
         end
       end
 
       # COMPLETED
-      completed = $redis.smembers('vmpooler__completed__' + pool['name'])
-      if completed
-        completed.each do |vm|
-          if inventory[vm]
-            begin
-              destroy_vm(vm, pool['name'])
-            rescue
-              $logger.log('s', "[!] [#{pool['name']}] '#{vm}' destroy appears to have failed")
-              $redis.srem('vmpooler__completed__' + pool['name'], vm)
-              $redis.hdel('vmpooler__active__' + pool['name'], vm)
-              $redis.del('vmpooler__vm__' + vm)
-            end
-          else
-            $logger.log('s', "[!] [#{pool['name']}] '#{vm}' not found in inventory, removed from 'completed' queue")
-            $redis.srem('vmpooler__completed__' + pool['name'], vm)
-            $redis.hdel('vmpooler__active__' + pool['name'], vm)
-            $redis.del('vmpooler__vm__' + vm)
+      $redis.smembers("vmpooler__completed__#{pool['name']}").each do |vm|
+        if inventory[vm]
+          begin
+            destroy_vm(vm, pool['name'], vsphere)
+          rescue
+            $logger.log('s', "[!] [#{pool['name']}] '#{vm}' destroy appears to have failed")
+            $redis.srem("vmpooler__completed__#{pool['name']}", vm)
+            $redis.hdel("vmpooler__active__#{pool['name']}", vm)
+            $redis.del("vmpooler__vm__#{vm}")
           end
+        else
+          $logger.log('s', "[!] [#{pool['name']}] '#{vm}' not found in inventory, removed from 'completed' queue")
+          $redis.srem("vmpooler__completed__#{pool['name']}", vm)
+          $redis.hdel("vmpooler__active__#{pool['name']}", vm)
+          $redis.del("vmpooler__vm__#{vm}")
         end
       end
 
       # DISCOVERED
-      discovered = $redis.smembers("vmpooler__discovered__#{pool['name']}")
-      if discovered
-        discovered.each do |vm|
-          %w(pending ready running completed).each do |queue|
-            if $redis.sismember('vmpooler__' + queue + '__' + pool['name'], vm)
-              $logger.log('d', "[!] [#{pool['name']}] '#{vm}' found in '#{queue}', removed from 'discovered' queue")
-              $redis.srem('vmpooler__discovered__' + pool['name'], vm)
-            end
+      $redis.smembers("vmpooler__discovered__#{pool['name']}").each do |vm|
+        %w(pending ready running completed).each do |queue|
+          if $redis.sismember("vmpooler__#{queue}__#{pool['name']}", vm)
+            $logger.log('d', "[!] [#{pool['name']}] '#{vm}' found in '#{queue}', removed from 'discovered' queue")
+            $redis.srem("vmpooler__discovered__#{pool['name']}", vm)
           end
+        end
 
-          if $redis.sismember('vmpooler__discovered__' + pool['name'], vm)
-            $redis.smove('vmpooler__discovered__' + pool['name'], 'vmpooler__completed__' + pool['name'], vm)
-          end
+        if $redis.sismember("vmpooler__discovered__#{pool['name']}", vm)
+          $redis.smove("vmpooler__discovered__#{pool['name']}", "vmpooler__completed__#{pool['name']}", vm)
         end
       end
 
       # MIGRATIONS
-      migrations = $redis.smembers('vmpooler__migrating__' + pool['name'])
-      if migrations
-        migrations.each do |vm|
-          if inventory[vm]
-            begin
-              migrate_vm(vm, pool['name'])
-            rescue => err
-              $logger.log('s', "[x] [#{pool['name']}] '#{vm}' failed to migrate: #{err}")
-            end
+      $redis.smembers("vmpooler__migrating__#{pool['name']}").each do |vm|
+        if inventory[vm]
+          begin
+            migrate_vm(vm, pool['name'], vsphere)
+          rescue => err
+            $logger.log('s', "[x] [#{pool['name']}] '#{vm}' failed to migrate: #{err}")
           end
         end
       end
 
       # REPOPULATE
-      ready = $redis.scard('vmpooler__ready__' + pool['name'])
-      total = $redis.scard('vmpooler__pending__' + pool['name']) + ready
+      ready = $redis.scard("vmpooler__ready__#{pool['name']}")
+      total = $redis.scard("vmpooler__pending__#{pool['name']}") + ready
 
-      $metrics.gauge('ready.' + pool['name'], $redis.scard('vmpooler__ready__' + pool['name']))
-      $metrics.gauge('running.' + pool['name'], $redis.scard('vmpooler__running__' + pool['name']))
+      $metrics.gauge("ready.#{pool['name']}", $redis.scard("vmpooler__ready__#{pool['name']}"))
+      $metrics.gauge("running.#{pool['name']}", $redis.scard("vmpooler__running__#{pool['name']}"))
 
-      if $redis.get('vmpooler__empty__' + pool['name'])
+      if $redis.get("vmpooler__empty__#{pool['name']}")
         unless ready == 0
-          $redis.del('vmpooler__empty__' + pool['name'])
+          $redis.del("vmpooler__empty__#{pool['name']}")
         end
       else
         if ready == 0
-          $redis.set('vmpooler__empty__' + pool['name'], 'true')
+          $redis.set("vmpooler__empty__#{pool['name']}", 'true')
           $logger.log('s', "[!] [#{pool['name']}] is empty")
         end
       end
@@ -673,10 +683,11 @@ module Vmpooler
                 pool['template'],
                 pool['folder'],
                 pool['datastore'],
-                pool['clone_target']
+                pool['clone_target'],
+                vsphere
               )
-            rescue
-              $logger.log('s', "[!] [#{pool['name']}] clone appears to have failed")
+            rescue => err
+              $logger.log('s', "[!] [#{pool['name']}] clone failed during check_pool with an error: #{err}")
               $redis.decr('vmpooler__tasks__clone')
             end
           end

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -26,7 +26,7 @@ module Vmpooler
     end
 
     def add_disk(vm, size, datastore)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       return false unless size.to_i > 0
 
@@ -76,14 +76,14 @@ module Vmpooler
     end
 
     def find_datastore(datastorename)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       datacenter = @connection.serviceInstance.find_datacenter
       datacenter.find_datastore(datastorename)
     end
 
     def find_device(vm, deviceName)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       vm.config.hardware.device.each do |device|
         return device if device.deviceInfo.label == deviceName
@@ -93,7 +93,7 @@ module Vmpooler
     end
 
     def find_disk_controller(vm)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       devices = find_disk_devices(vm)
 
@@ -107,7 +107,7 @@ module Vmpooler
     end
 
     def find_disk_devices(vm)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       devices = {}
 
@@ -135,7 +135,7 @@ module Vmpooler
     end
 
     def find_disk_unit_number(vm, controller)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       used_unit_numbers = []
       available_unit_numbers = []
@@ -160,7 +160,7 @@ module Vmpooler
     end
 
     def find_folder(foldername)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       datacenter = @connection.serviceInstance.find_datacenter
       base = datacenter.vmFolder
@@ -221,7 +221,7 @@ module Vmpooler
     end
 
     def find_least_used_host(cluster)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       cluster_object = find_cluster(cluster)
       target_hosts = get_cluster_host_utilization(cluster_object)
@@ -244,7 +244,7 @@ module Vmpooler
     end
 
     def find_least_used_compatible_host(vm)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       source_host = vm.summary.runtime.host
       model = get_host_cpu_arch_version(source_host)
@@ -259,7 +259,7 @@ module Vmpooler
     end
 
     def find_pool(poolname)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       datacenter = @connection.serviceInstance.find_datacenter
       base = datacenter.hostFolder
@@ -288,13 +288,13 @@ module Vmpooler
     end
 
     def find_vm(vmname)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       @connection.searchIndex.FindByDnsName(vmSearch: true, dnsName: vmname)
     end
 
     def find_vm_heavy(vmname)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       vmname = vmname.is_a?(Array) ? vmname : [vmname]
       containerView = get_base_vm_container_from @connection
@@ -344,7 +344,7 @@ module Vmpooler
     end
 
     def find_vmdks(vmname, datastore)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       disks = []
 
@@ -363,7 +363,7 @@ module Vmpooler
     end
 
     def get_base_vm_container_from(connection)
-      ensure_connected @connection
+      ensure_connected @connection, $credentials
 
       viewManager = connection.serviceContent.viewManager
       viewManager.CreateContainerView(

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -254,7 +254,8 @@ module Vmpooler
         host_usage = get_host_utilization(host, model)
         target_hosts << host_usage if host_usage
       end
-      target_hosts.sort[0][1]
+      target_host = target_hosts.sort[0][1]
+      [target_host, target_host.name]
     end
 
     def find_pool(poolname)

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -17,11 +17,7 @@ module Vmpooler
     end
 
     def add_disk(vm, size, datastore)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       return false unless size.to_i > 0
 
@@ -71,22 +67,14 @@ module Vmpooler
     end
 
     def find_datastore(datastorename)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       datacenter = @connection.serviceInstance.find_datacenter
       datacenter.find_datastore(datastorename)
     end
 
     def find_device(vm, deviceName)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       vm.config.hardware.device.each do |device|
         return device if device.deviceInfo.label == deviceName
@@ -96,11 +84,7 @@ module Vmpooler
     end
 
     def find_disk_controller(vm)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       devices = find_disk_devices(vm)
 
@@ -114,11 +98,7 @@ module Vmpooler
     end
 
     def find_disk_devices(vm)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       devices = {}
 
@@ -146,11 +126,7 @@ module Vmpooler
     end
 
     def find_disk_unit_number(vm, controller)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       used_unit_numbers = []
       available_unit_numbers = []
@@ -175,11 +151,7 @@ module Vmpooler
     end
 
     def find_folder(foldername)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       datacenter = @connection.serviceInstance.find_datacenter
       base = datacenter.vmFolder
@@ -196,39 +168,96 @@ module Vmpooler
       base
     end
 
-    def find_least_used_host(cluster)
+    # Returns an array containing cumulative CPU and memory utilization of a host, and its object reference
+    # Params:
+    # +model+:: CPU arch version to match on
+    # +limit+:: Hard limit for CPU or memory utilization beyond which a host is excluded for deployments
+    def get_host_utilization(host, model=nil, limit=90)
+      if model
+        return nil unless host_has_cpu_model? host, model
+      end
+      return nil if host.runtime.inMaintenanceMode
+      return nil unless host.overallStatus == 'green'
+
+      cpu_utilization = cpu_utilization_for host
+      memory_utilization = memory_utilization_for host
+
+      return nil if cpu_utilization > limit
+      return nil if memory_utilization > limit
+
+      [ cpu_utilization + memory_utilization, host ]
+    end
+
+    def host_has_cpu_model?(host, model)
+       get_host_cpu_arch_version(host) == model
+    end
+
+    def get_host_cpu_arch_version(host)
+      cpu_model = host.hardware.cpuPkg[0].description
+      cpu_model_parts = cpu_model.split()
+      arch_version = cpu_model_parts[4]
+      arch_version
+    end
+
+    def cpu_utilization_for(host)
+      cpu_usage = host.summary.quickStats.overallCpuUsage
+      cpu_size = host.summary.hardware.cpuMhz * host.summary.hardware.numCpuCores
+      (cpu_usage.to_f / cpu_size.to_f) * 100
+    end
+
+    def memory_utilization_for(host)
+      memory_usage = host.summary.quickStats.overallMemoryUsage
+      memory_size = host.summary.hardware.memorySize / 1024 / 1024
+      (memory_usage.to_f / memory_size.to_f) * 100
+    end
+
+    def vsphere_connection_alive?(connection)
       begin
-        @connection.serviceInstance.CurrentTime
+        connection.serviceInstance.CurrentTime
       rescue
         initialize
       end
+    end
 
-      hosts = {}
-      hosts_sort = {}
+    def find_least_used_host(cluster)
+      vsphere_connection_alive? @connection
 
+      cluster_object = find_cluster(cluster)
+      target_hosts = get_cluster_host_utilization(cluster_object)
+      least_used_host = target_hosts.sort[0][1]
+      least_used_host
+    end
+
+    def find_cluster(cluster)
       datacenter = @connection.serviceInstance.find_datacenter
-      datacenter.hostFolder.children.each do |folder|
-        next unless folder.name == cluster
-        folder.host.each do |host|
-          if
-            (host.overallStatus == 'green') &&
-            (!host.runtime.inMaintenanceMode)
+      datacenter.hostFolder.children.find { |cluster_object| cluster_object.name == cluster }
+    end
 
-            hosts[host.name] = host
-            hosts_sort[host.name] = host.vm.length
-          end
-        end
+    def get_cluster_host_utilization(cluster)
+      cluster_hosts = []
+      cluster.host.each do |host|
+        host_usage = get_host_utilization(host)
+        cluster_hosts << host_usage if host_usage
       end
+      cluster_hosts
+    end
 
-      hosts[hosts_sort.sort_by { |_k, v| v }[0][0]]
+    def find_least_used_compatible_host(vm)
+      vsphere_connection_alive? @connection
+
+      source_host = vm.summary.runtime.host
+      model = get_host_cpu_arch_version(source_host)
+      cluster = source_host.parent
+      target_hosts = []
+      cluster.host.each do |host|
+        host_usage = get_host_utilization(host, model)
+        target_hosts << host_usage if host_usage
+      end
+      target_hosts.sort[0][1]
     end
 
     def find_pool(poolname)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       datacenter = @connection.serviceInstance.find_datacenter
       base = datacenter.hostFolder
@@ -257,21 +286,13 @@ module Vmpooler
     end
 
     def find_vm(vmname)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       @connection.searchIndex.FindByDnsName(vmSearch: true, dnsName: vmname)
     end
 
     def find_vm_heavy(vmname)
-      begin
-        @connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       vmname = vmname.is_a?(Array) ? vmname : [vmname]
       containerView = get_base_vm_container_from @connection
@@ -321,11 +342,7 @@ module Vmpooler
     end
 
     def find_vmdks(vmname, datastore)
-      begin
-        connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       disks = []
 
@@ -344,11 +361,7 @@ module Vmpooler
     end
 
     def get_base_vm_container_from(connection)
-      begin
-        connection.serviceInstance.CurrentTime
-      rescue
-        initialize
-      end
+      vsphere_connection_alive? @connection
 
       viewManager = connection.serviceContent.viewManager
       viewManager.CreateContainerView(
@@ -370,6 +383,11 @@ module Vmpooler
       end
 
       snapshot
+    end
+
+    def migrate_vm_host(vm, host)
+      relospec = RbVmomi::VIM.VirtualMachineRelocateSpec(host: host)
+      vm.RelocateVM_Task(spec: relospec).wait_for_completion
     end
 
     def close

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -289,6 +289,11 @@ module Vmpooler
 
     def find_vm(vmname)
       ensure_connected @connection, $credentials
+      find_vm_light(vmname) || find_vm_heavy(vmname)[vmname]
+    end
+
+    def find_vm_light(vmname)
+      ensure_connected @connection, $credentials
 
       @connection.searchIndex.FindByDnsName(vmSearch: true, dnsName: vmname)
     end

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -17,7 +17,7 @@ module Vmpooler
     end
 
     def add_disk(vm, size, datastore)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       return false unless size.to_i > 0
 
@@ -67,14 +67,14 @@ module Vmpooler
     end
 
     def find_datastore(datastorename)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       datacenter = @connection.serviceInstance.find_datacenter
       datacenter.find_datastore(datastorename)
     end
 
     def find_device(vm, deviceName)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       vm.config.hardware.device.each do |device|
         return device if device.deviceInfo.label == deviceName
@@ -84,7 +84,7 @@ module Vmpooler
     end
 
     def find_disk_controller(vm)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       devices = find_disk_devices(vm)
 
@@ -98,7 +98,7 @@ module Vmpooler
     end
 
     def find_disk_devices(vm)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       devices = {}
 
@@ -126,7 +126,7 @@ module Vmpooler
     end
 
     def find_disk_unit_number(vm, controller)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       used_unit_numbers = []
       available_unit_numbers = []
@@ -151,7 +151,7 @@ module Vmpooler
     end
 
     def find_folder(foldername)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       datacenter = @connection.serviceInstance.find_datacenter
       base = datacenter.vmFolder
@@ -211,7 +211,7 @@ module Vmpooler
       (memory_usage.to_f / memory_size.to_f) * 100
     end
 
-    def vsphere_connection_alive?(connection)
+    def ensure_connected(connection)
       begin
         connection.serviceInstance.CurrentTime
       rescue
@@ -220,7 +220,7 @@ module Vmpooler
     end
 
     def find_least_used_host(cluster)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       cluster_object = find_cluster(cluster)
       target_hosts = get_cluster_host_utilization(cluster_object)
@@ -243,7 +243,7 @@ module Vmpooler
     end
 
     def find_least_used_compatible_host(vm)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       source_host = vm.summary.runtime.host
       model = get_host_cpu_arch_version(source_host)
@@ -257,7 +257,7 @@ module Vmpooler
     end
 
     def find_pool(poolname)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       datacenter = @connection.serviceInstance.find_datacenter
       base = datacenter.hostFolder
@@ -286,13 +286,13 @@ module Vmpooler
     end
 
     def find_vm(vmname)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       @connection.searchIndex.FindByDnsName(vmSearch: true, dnsName: vmname)
     end
 
     def find_vm_heavy(vmname)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       vmname = vmname.is_a?(Array) ? vmname : [vmname]
       containerView = get_base_vm_container_from @connection
@@ -342,7 +342,7 @@ module Vmpooler
     end
 
     def find_vmdks(vmname, datastore)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       disks = []
 
@@ -361,7 +361,7 @@ module Vmpooler
     end
 
     def get_base_vm_container_from(connection)
-      vsphere_connection_alive? @connection
+      ensure_connected @connection
 
       viewManager = connection.serviceContent.viewManager
       viewManager.CreateContainerView(

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -50,11 +50,21 @@ def create_pending_vm(template, name, token = nil)
   redis.hset("vmpooler__vm__#{name}", "template", template)
 end
 
-def create_vm(name, token = nil)
-  redis.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
-  if token
-    redis.hset("vmpooler__vm__#{name}", 'token:token', token)
-  end
+def create_vm(name, token = nil, redis_handle = nil)
+  redis_db = redis_handle ? redis_handle : redis
+  redis_db.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
+  redis_db.hset("vmpooler__vm__#{name}", 'token:token', token) if token
+end
+
+def create_migrating_vm(name, pool, redis_handle = nil)
+  redis_db = redis_handle ? redis_handle : redis
+  redis_db.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
+  redis_db.sadd("vmpooler__migrating__#{pool}", name)
+end
+
+def add_vm_to_migration_set(name, redis_handle = nil)
+  redis_db = redis_handle ? redis_handle : redis
+  redis_db.sadd('vmpooler__migration', name)
 end
 
 def fetch_vm(vm)

--- a/spec/vmpooler/pool_manager_migration_spec.rb
+++ b/spec/vmpooler/pool_manager_migration_spec.rb
@@ -1,0 +1,88 @@
+require 'spec_helper'
+require 'mock_redis'
+require 'time'
+
+describe 'Pool Manager' do
+  let(:logger) { double('logger') }
+  let(:redis) { MockRedis.new }
+  let(:metrics) { Vmpooler::DummyStatsd.new }
+  let(:config) {
+    {
+      config: {
+        'site_name' => 'test pooler',
+        'migration_limit' => 2,
+        vsphere: {
+          'server' => 'vsphere.puppet.com',
+          'username' => 'vmpooler@vsphere.local',
+          'password' => '',
+          'insecure' => true
+        },
+        pools: [ {'name' => 'pool1', 'size' => 5, 'folder' => 'pool1_folder'} ],
+        statsd: { 'prefix' => 'stats_prefix'},
+        pool_names: [ 'pool1' ]
+      }
+    }
+  }
+  let(:pool) { config[:config][:pools][0]['name'] }
+  let(:vm) {
+    {
+      'name' => 'vm1',
+      'host' => 'host1',
+      'template' => pool,
+    }
+  }
+
+  describe '#_migrate_vm' do
+    let(:vsphere) { double(pool) }
+    let(:pooler) { Vmpooler::PoolManager.new(config, logger, redis, metrics) }
+    context 'evaluates VM for migration and logs host' do
+      before do
+        create_migrating_vm vm['name'], pool, redis
+        allow(vsphere).to receive(:find_vm).and_return(vm)
+        allow(pooler).to receive(:get_vm_host_info).and_return([{'name' => 'host1'}, 'host1'])
+        expect(vsphere).to receive(:find_vm).with(vm['name'])
+      end
+
+      it 'logs VM host when migration is disabled' do
+        config[:config]['migration_limit'] = nil
+
+        expect(redis.sismember("vmpooler__migrating__#{pool}", vm['name'])).to be true
+        expect(logger).to receive(:log).with('s', "[ ] [#{pool}] '#{vm['name']}' is running on #{vm['host']}")
+
+        pooler._migrate_vm(vm['name'], pool, vsphere)
+
+        expect(redis.sismember("vmpooler__migrating__#{pool}", vm['name'])).to be false
+      end
+
+      it 'verifies that migration_limit greater than or equal to migrations in progress and logs host' do
+        add_vm_to_migration_set vm['name'], redis
+        add_vm_to_migration_set 'vm2', redis
+
+        expect(logger).to receive(:log).with('s', "[ ] [#{pool}] '#{vm['name']}' is running on #{vm['host']}. No migration will be evaluated since the migration_limit has been reached")
+
+        pooler._migrate_vm(vm['name'], pool, vsphere)
+      end
+
+      it 'verifies that migration_limit is less than migrations in progress and logs old host, new host and migration time' do
+        allow(vsphere).to receive(:find_least_used_compatible_host).and_return([{'name' => 'host2'}, 'host2'])
+        allow(vsphere).to receive(:migrate_vm_host)
+
+        expect(redis.hget("vmpooler__vm__#{vm['name']}", 'migration_time'))
+        expect(redis.hget("vmpooler__vm__#{vm['name']}", 'checkout_to_migration'))
+        expect(logger).to receive(:log).with('s', "[>] [#{pool}] '#{vm['name']}' migrated from #{vm['host']} to host2 in 0.00 seconds")
+
+        pooler._migrate_vm(vm['name'], pool, vsphere)
+      end
+
+      it 'fails when no suitable host can be found' do
+        error = 'ArgumentError: No target host found'
+        allow(vsphere).to receive(:find_least_used_compatible_host)
+        allow(vsphere).to receive(:migrate_vm_host).and_raise(error)
+
+        expect(logger).to receive(:log).with('s', "[x] [#{pool}] '#{vm['name']}' migration failed with an error: #{error}")
+
+        pooler._migrate_vm(vm['name'], pool, vsphere)
+      end
+    end
+  end
+end

--- a/spec/vmpooler/pool_manager_migration_spec.rb
+++ b/spec/vmpooler/pool_manager_migration_spec.rb
@@ -40,7 +40,6 @@ describe 'Pool Manager' do
         create_migrating_vm vm['name'], pool, redis
         allow(vsphere).to receive(:find_vm).and_return(vm)
         allow(pooler).to receive(:get_vm_host_info).and_return([{'name' => 'host1'}, 'host1'])
-        expect(vsphere).to receive(:find_vm).with(vm['name'])
       end
 
       it 'logs VM host when migration is disabled' do

--- a/spec/vmpooler/pool_manager_spec.rb
+++ b/spec/vmpooler/pool_manager_spec.rb
@@ -26,7 +26,6 @@ describe 'Pool Manager' do
       it 'calls fail_pending_vm' do
         allow(vsphere).to receive(:find_vm).and_return(nil)
         allow(redis).to receive(:hget)
-        expect(redis).to receive(:hget).with(String, 'clone').once
         subject._check_pending_vm(vm, pool, timeout, vsphere)
       end
     end

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -225,6 +225,13 @@
 #     If set, prefixes all created VMs with this string.  This should include
 #     a separator.
 #     (optional; default: '')
+#
+#   - migration_limit
+#     When set to any value greater than 0 enable VM migration at checkout.
+#     When enabled this capability will evaluate a VM for migration when it is requested
+#     in an effort to maintain a more even distribution of load across compute resources.
+#     The migration_limit ensures that no more than n migrations will be evaluated at any one time
+#     and greatly reduces the possibilty of VMs ending up bunched together on a particular host.
 
 # Example:
 


### PR DESCRIPTION
This change implements improved scheduling of pooled VMs by updating the logic used to find the least used host in a target cluster. Without this change host selection is based on VM count, which does not give an indication of VM size or current host utilization.

Additionally, this change implements a queue for migrating VMs at request time. The least used compatible host is selected for migration, which occurs transparently to the consumer, and migration is performed if required.

Without these changes vmpooler may cause uneven load distribution across a cluster of resources since the consumption of VMs is separated from scheduling.
