### PR TITLE
Containerize vmpooler

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM jruby:1.7-jdk
 RUN mkdir -p /var/lib/vmpooler
 WORKDIR /var/lib/vmpooler
 
-ADD Gemfile /var/lib/vmpooler
-ADD Gemfile.lock /var/lib/vmpooler
+ADD Gemfile* /var/lib/vmpooler
 RUN bundle install --system
 
 RUN ln -s /opt/jruby/bin/jruby /usr/bin/jruby

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM jruby:1.7-jdk
+
+RUN mkdir -p /var/lib/vmpooler
+WORKDIR /var/lib/vmpooler
+
+ADD Gemfile /var/lib/vmpooler
+ADD Gemfile.lock /var/lib/vmpooler
+RUN bundle install --system
+
+RUN ln -s /opt/jruby/bin/jruby /usr/bin/jruby
+
+RUN echo "deb http://httpredir.debian.org/debian jessie main" >/etc/apt/sources.list.d/jessie-main.list
+RUN apt-get update
+RUN apt-get install -y redis-server
+
+COPY . /var/lib/vmpooler
+
+ENTRYPOINT \
+    /etc/init.d/redis-server start \
+    && /var/lib/vmpooler/scripts/vmpooler_init.sh start \
+    && while [ ! -f /var/log/vmpooler.log ]; do sleep 1; done ; \
+    tail -f /var/log/vmpooler.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+# Run vmpooler in a Docker container!  Configuration can either be embedded
+# and built within the current working directory, or stored in a
+# VMPOOLER_CONFIG environment value and passed to the Docker daemon.
+#
+# BUILD:
+#   docker build -t vmpooler .
+#
+# RUN:
+#   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
+
 FROM jruby:1.7-jdk
 
 RUN mkdir -p /var/lib/vmpooler

--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ The following YAML configuration sets up two pools, `debian-7-i386` and `debian-
 
 See the provided YAML configuration example, [vmpooler.yaml.example](vmpooler.yaml.example), for additional configuration options and parameters.
 
+### Running via Docker
+
+A [Dockerfile](Dockerfile) is included in this repository to allow running vmpooler inside a Docker container.  A `vmpooler.yaml` configuration file can be embedded in the current working directory, or specified inline in a `VMPOOLER_CONFIG` environment variable.  To build and run:
+
+```
+docker build -t vmpooler . && docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
+```
+
 ### Template set-up
 
 Template set-up is left as an exercise to the reader.  Somehow, either via PXE, embedded bootstrap scripts, or some other method -- clones of VM templates need to be able to set their hostname, register themselves in your DNS, and be resolvable by the vmpooler application after completing the clone task and booting up.

--- a/README.md
+++ b/README.md
@@ -65,11 +65,6 @@ A [Dockerfile](Dockerfile) is included in this repository to allow running vmpoo
 docker build -t vmpooler . && docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 ```
 
-### Template set-up
-
-Template set-up is left as an exercise to the reader.  Somehow, either via PXE, embedded bootstrap scripts, or some other method -- clones of VM templates need to be able to set their hostname, register themselves in your DNS, and be resolvable by the vmpooler application after completing the clone task and booting up.
-
-
 ## API and Dashboard
 
 vmpooler provides an API and web front-end (dashboard) on port `:4567`.  See the provided YAML configuration example, [vmpooler.yaml.example](vmpooler.yaml.example), to specify an alternative port to listen on.

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -21,11 +21,18 @@ module Vmpooler
   end
 
   def self.config(filepath='vmpooler.yaml')
-    # Load the configuration file
-    config_file = File.expand_path(filepath)
-    parsed_config = YAML.load_file(config_file)
+    parsed_config = {}
 
-    # Set some defaults
+    if ENV['VMPOOLER_CONFIG']
+      # Load configuration from ENV
+      parsed_config = YAML.load(ENV['VMPOOLER_CONFIG'])
+    else
+      # Load the configuration file from disk
+      config_file = File.expand_path(filepath)
+      parsed_config = YAML.load_file(config_file)
+    end
+
+    # Set some configuration defaults
     parsed_config[:redis]             ||= {}
     parsed_config[:redis]['server']   ||= 'localhost'
     parsed_config[:redis]['data_ttl'] ||= 168


### PR DESCRIPTION
Built off the [jruby](https://hub.docker.com/_/jruby/) `Dockerfile`, it installs gem requirements via `bundler`, installs and runs a `redis-server`, imports the current working directory, starts `vmpooler`, and tails the logfile.

Creating a `vmpooler.yaml` configuration file in the current working directory and running the following provides a development environment:

```
docker build -t vmpooler . && docker run -p 80:4567 -it vmpooler
```