### PR TITLE
Fix JavaScript error on nil `weekly_data`

### DIFF
--- a/lib/vmpooler/public/lib/dashboard.js
+++ b/lib/vmpooler/public/lib/dashboard.js
@@ -4,8 +4,12 @@ var date_from = new Date();
 
 var running_data = {};
 var weekly_data = {
+  platform_count: {},
   clone_max: 0,
-  clone_platform_max: 0
+  clone_platform_max: 0,
+  clone_count: [],
+  clone_avg: [],
+  boot_avg: []
 };
 var capacity_data = {};
 


### PR DESCRIPTION
Without this patch the dashboard will error-out on unfound `weekly_data` values.