### PR TITLE
(POOLER-44) Fix vmpooler.migrate reference

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -413,7 +413,7 @@ module Vmpooler
     def check_disk_queue
       $logger.log('d', "[*] [disk_manager] starting worker thread")
 
-      $vsphere['disk_manager'] ||= Vmpooler::VsphereHelper.new $config[:vsphere]
+      $vsphere['disk_manager'] ||= Vmpooler::VsphereHelper.new $config[:vsphere], $metrics
 
       $threads['disk_manager'] = Thread.new do
         loop do
@@ -439,7 +439,7 @@ module Vmpooler
     def check_snapshot_queue
       $logger.log('d', "[*] [snapshot_manager] starting worker thread")
 
-      $vsphere['snapshot_manager'] ||= Vmpooler::VsphereHelper.new $config[:vsphere]
+      $vsphere['snapshot_manager'] ||= Vmpooler::VsphereHelper.new $config[:vsphere], $metrics
 
       $threads['snapshot_manager'] = Thread.new do
         loop do
@@ -547,7 +547,7 @@ module Vmpooler
     def check_pool(pool)
       $logger.log('d', "[*] [#{pool['name']}] starting worker thread")
 
-      $vsphere[pool['name']] ||= Vmpooler::VsphereHelper.new $config[:vsphere]
+      $vsphere[pool['name']] ||= Vmpooler::VsphereHelper.new $config[:vsphere], $metrics
 
       $threads[pool['name']] = Thread.new do
         loop do

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -6,16 +6,16 @@ module Vmpooler
     DISK_TYPE = 'thin'
     DISK_MODE = 'persistent'
 
-    def initialize(credentials)
+    def initialize(credentials, metrics)
       $credentials = credentials
+      $metrics = metrics
     end
 
     def ensure_connected(connection, credentials)
-      begin
-        connection.serviceInstance.CurrentTime
-      rescue
-        connect_to_vsphere $credentials
-      end
+      connection.serviceInstance.CurrentTime
+    rescue
+      $metrics.increment("connect.open")
+      connect_to_vsphere $credentials
     end
 
     def connect_to_vsphere(credentials)


### PR DESCRIPTION
This commit updates vmpooler.migrate metric to send the pool name. Without this change the VM name is sent. Additionally, counts are added for migrate_from_#host and migrate_to_#host in order to allow tracking host migrations, and correlating them with CPU ready time changes.