### PR TITLE
(maint) Enhance VM Pooler developer experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .ruby-version
 Gemfile.lock
+Gemfile.local
 vendor
+vmpooler.yaml
+.bundle
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -23,3 +23,13 @@ group :test do
   gem 'simplecov', '>= 0.11.2'
   gem 'yarjuf', '>= 2.0'
 end
+
+# Evaluate Gemfile.local if it exists
+if File.exists? "#{__FILE__}.local"
+  instance_eval(File.read("#{__FILE__}.local"))
+end
+
+# Evaluate ~/.gemfile if it exists
+if File.exists?(File.join(Dir.home, '.gemfile'))
+  instance_eval(File.read(File.join(Dir.home, '.gemfile')))
+end

--- a/vmpooler
+++ b/vmpooler
@@ -26,4 +26,11 @@ manager = Thread.new {
   ).execute!
 }
 
+if ENV['VMPOOLER_DEBUG']
+  trap("INT") {
+    puts "Shutting down."
+    [api, manager].each { |t| t.exit }
+  }
+end
+
 [api, manager].each { |t| t.join }


### PR DESCRIPTION
Previously, a bundle install would not pull in gems from Gemfile.local or
~/.gemfile which are common development workflows in Puppet.  This commit
modifies the Gemfile to pull in these additional gemfiles if they exist.  This
commit also adds common files and folders to gitignore which should not be
committed to this repository.

Previously, if you ran the vpooler via ruby, pressing Ctrl-C would terminate the
Webserver however the PoolManager does not have a handler and would instead
just keep executing.  This commit adds a global Ctrl-C hook which terminates
both the api and manager threads.  This behaviour will only be enabled if the
`VMPOOLER_DEBUG` environment variable exists so that it does not affect VMPooler
when running in production environments.
