### PR TITLE
(maint) Remove Ruby 1.9.3 testing from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: ruby
 services:
   - redis-server
 rvm:
-  - 1.9.3
   - 2.1.1
   - 2.2.1
   - 2.2.2


### PR DESCRIPTION
Ruby 1.9.3 is end of life, and now longer bundles due to later Nokogiri 1.7.0.1
requiring Ruby 2.1 or above.  This commit removes ruby 1.9.3 from Travis
testing.