### PR TITLE
(POOLER-71) Add dummy authentication provider

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -32,6 +32,19 @@ module Vmpooler
       parsed_config = YAML.load_file(config_file)
     end
 
+    # Bail out if someone attempts to start vmpooler with dummy authentication
+    # without enbaling debug mode.
+    if parsed_config[:auth]['provider'] == 'dummy'
+      unless ENV['VMPOOLER_DEBUG']
+        warning = [
+          "Dummy authentication should not be used outside of debug mode",
+          "please set environment variable VMPOOLER_DEBUG to 'true' if you want to use dummy authentication",
+        ]
+
+        raise warning.join(";\s")
+      end
+    end
+
     # Set some configuration defaults
     parsed_config[:redis]             ||= {}
     parsed_config[:redis]['server']   ||= 'localhost'

--- a/lib/vmpooler/api/helpers.rb
+++ b/lib/vmpooler/api/helpers.rb
@@ -56,6 +56,8 @@ module Vmpooler
 
       def authenticate(auth, username_str, password_str)
         case auth['provider']
+          when 'dummy'
+            return (username_str != password_str)
           when 'ldap'
             require 'rubygems'
             require 'net/ldap'

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -137,8 +137,22 @@
 # This section contains information related to authenticating users
 # for token operations.
 #
-# Currently the only supported provider is LDAP; the following parameters
-# will all be under an ':ldap:' subsection (see example below).
+# Supported Auth Providers:
+#   - Dummy
+#   - LDAP
+#
+# - Dummy Auth Provider
+# The Dummy Authentication provider should only be used during development or testing
+# If the Username and Password are different then validation succeeds
+# If the Username and Password are the same then validation fails
+#
+# Example:
+# :auth:
+#   provider: 'dummy'
+#
+# - LDAP Auth Provider
+# The LDAP Authentication provider will validate usernames and passwords against an
+# existing LDAP service
 #
 # Available configuration parameters:
 #
@@ -154,8 +168,15 @@
 #
 #   - user_object
 #     The LDAP object-type used to designate a user object.
-
+#
 # Example:
+# :auth:
+#   provider: 'ldap'
+#   :ldap:
+#     host: 'localhost'
+#     port: 389
+#     base: 'ou=users,dc=company,dc=com'
+#     user_object: 'uid'
 
 :auth:
   provider: 'ldap'


### PR DESCRIPTION
Previously it was difficult to do local development as VMPooler requires an LDAP
service for authentication. This commit adds a dummy authentication provider.
The provider has passes authentication if the username and password are
different, and fails if the username and password are the same.  This commit
also updates the documentation in the config YML file.