### PR TITLE
(maint) Only load rubocop rake tasks if gem is available

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 require 'rspec/core/rake_task'
-require 'rubocop/rake_task'
+
+rubocop_available = Gem::Specification::find_all_by_name('rubocop').any?
+require 'rubocop/rake_task' if rubocop_available
 
 desc 'Run rspec tests with coloring.'
 RSpec::Core::RakeTask.new(:test) do |t|
@@ -13,9 +15,11 @@ RSpec::Core::RakeTask.new(:junit) do |t|
   t.pattern    = 'spec/'
 end
 
-desc 'Run RuboCop'
-RuboCop::RakeTask.new(:rubocop) do |task|
-  task.options << '--display-cop-names'
+if rubocop_available
+  desc 'Run RuboCop'
+  RuboCop::RakeTask.new(:rubocop) do |task|
+    task.options << '--display-cop-names'
+  end
 end
 
 task :default => [:test]


### PR DESCRIPTION
Previously in commit 145ecb443f Rakefile was modified to require the Rubocop
gem however, this gem is not available on jruby systems and would throw errors.
This commit modifies the Rakefile to first detect if the Gem is available and
optionally load the rubocop rake tasks.