### PR TITLE
(GH-185) Remove unnecessary checks in check_ready_vm 

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -102,6 +102,7 @@ module Vmpooler
             $redis.smove('vmpooler__ready__' + pool, 'vmpooler__completed__' + pool, vm)
 
             $logger.log('d', "[!] [#{pool}] '#{vm}' reached end of TTL after #{ttl} minutes, removed from 'ready' queue")
+            return
           end
         end
 
@@ -124,6 +125,7 @@ module Vmpooler
               $redis.smove('vmpooler__ready__' + pool, 'vmpooler__completed__' + pool, vm)
 
               $logger.log('d', "[!] [#{pool}] '#{vm}' appears to be powered off, removed from 'ready' queue")
+              return
             end
 
             if
@@ -134,6 +136,7 @@ module Vmpooler
               $redis.smove('vmpooler__ready__' + pool, 'vmpooler__completed__' + pool, vm)
 
               $logger.log('d', "[!] [#{pool}] '#{vm}' has mismatched hostname, removed from 'ready' queue")
+              return
             end
           else
             $redis.srem('vmpooler__ready__' + pool, vm)
@@ -149,6 +152,7 @@ module Vmpooler
             else
               $logger.log('d', "[!] [#{pool}] '#{vm}' is unreachable, and failed to remove from 'ready' queue")
             end
+            return
           end
         end
       end


### PR DESCRIPTION
Previously in check_ready_vm, if the VM is powered off, the VM is moved in
redis however the function doesn't return there, and instead then checks if the
hostname is the same, and then if TCP socket 22 is open. This is unnecessary as
we already know the VM is turned off so of course the hostname is wrong and TCP
22 is unavailable. The same applies for the VM hostname.

This commit instead returns after it is found a VM is no longer ready.  This
commit also amends the spec tests for the correct behaviour.

~~Note - This PR is blocked on PR #183 being merged~~