### PR TITLE
(POOLER-70) Refactor clone_vm to take pool configuration object

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -185,103 +185,111 @@ module Vmpooler
     end
 
     # Clone a VM
-    def clone_vm(template, folder, datastore, target, vsphere)
+    def clone_vm(pool, vsphere)
       Thread.new do
         begin
-          vm = {}
-
-          if template =~ /\//
-            templatefolders = template.split('/')
-            vm['template'] = templatefolders.pop
-          end
-
-          if templatefolders
-            vm[vm['template']] = vsphere.find_folder(templatefolders.join('/')).find(vm['template'])
-          else
-            fail 'Please provide a full path to the template'
-          end
-
-          if vm['template'].length == 0
-            fail "Unable to find template '#{vm['template']}'!"
-          end
-
-          # Generate a randomized hostname
-          o = [('a'..'z'), ('0'..'9')].map(&:to_a).flatten
-          vm['hostname'] = $config[:config]['prefix'] + o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
-
-          # Add VM to Redis inventory ('pending' pool)
-          $redis.sadd('vmpooler__pending__' + vm['template'], vm['hostname'])
-          $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone', Time.now)
-          $redis.hset('vmpooler__vm__' + vm['hostname'], 'template', vm['template'])
-
-          # Annotate with creation time, origin template, etc.
-          # Add extraconfig options that can be queried by vmtools
-          configSpec = RbVmomi::VIM.VirtualMachineConfigSpec(
-            annotation: JSON.pretty_generate(
-                name: vm['hostname'],
-                created_by: $config[:vsphere]['username'],
-                base_template: vm['template'],
-                creation_timestamp: Time.now.utc
-            ),
-            extraConfig: [
-                { key: 'guestinfo.hostname',
-                  value: vm['hostname']
-                }
-            ]
-          )
-
-          # Choose a clone target
-          if target
-            $clone_target = vsphere.find_least_used_host(target)
-          elsif $config[:config]['clone_target']
-            $clone_target = vsphere.find_least_used_host($config[:config]['clone_target'])
-          end
-
-          # Put the VM in the specified folder and resource pool
-          relocateSpec = RbVmomi::VIM.VirtualMachineRelocateSpec(
-            datastore: vsphere.find_datastore(datastore),
-            host: $clone_target,
-            diskMoveType: :moveChildMostDiskBacking
-          )
-
-          # Create a clone spec
-          spec = RbVmomi::VIM.VirtualMachineCloneSpec(
-            location: relocateSpec,
-            config: configSpec,
-            powerOn: true,
-            template: false
-          )
-
-          # Clone the VM
-          $logger.log('d', "[ ] [#{vm['template']}] '#{vm['hostname']}' is being cloned from '#{vm['template']}'")
-
-          begin
-            start = Time.now
-            vm[vm['template']].CloneVM_Task(
-              folder: vsphere.find_folder(folder),
-              name: vm['hostname'],
-              spec: spec
-            ).wait_for_completion
-            finish = '%.2f' % (Time.now - start)
-
-            $redis.hset('vmpooler__clone__' + Date.today.to_s, vm['template'] + ':' + vm['hostname'], finish)
-            $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone_time', finish)
-
-            $logger.log('s', "[+] [#{vm['template']}] '#{vm['hostname']}' cloned from '#{vm['template']}' in #{finish} seconds")
-          rescue => err
-            $logger.log('s', "[!] [#{vm['template']}] '#{vm['hostname']}' clone failed with an error: #{err}")
-            $redis.srem('vmpooler__pending__' + vm['template'], vm['hostname'])
-            raise
-          end
-
-          $redis.decr('vmpooler__tasks__clone')
-
-          $metrics.timing("clone.#{vm['template']}", finish)
+          _clone_vm(pool, vsphere)
         rescue => err
-          $logger.log('s', "[!] [#{vm['template']}] '#{vm['hostname']}' failed while preparing to clone with an error: #{err}")
+          $logger.log('s', "[!] [#{pool['name']}] failed while cloning VM with an error: #{err}")
           raise
         end
       end
+    end
+
+    def _clone_vm(pool, vsphere)
+      template = pool['template']
+      folder = pool['folder']
+      datastore = pool['datastore']
+      target = pool['clone_target']
+      vm = {}
+
+      if template =~ /\//
+        templatefolders = template.split('/')
+        vm['template'] = templatefolders.pop
+      end
+
+      if templatefolders
+        vm[vm['template']] = vsphere.find_folder(templatefolders.join('/')).find(vm['template'])
+      else
+        fail 'Please provide a full path to the template'
+      end
+
+      if vm['template'].length == 0
+        fail "Unable to find template '#{vm['template']}'!"
+      end
+
+      # Generate a randomized hostname
+      o = [('a'..'z'), ('0'..'9')].map(&:to_a).flatten
+      vm['hostname'] = $config[:config]['prefix'] + o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
+
+      # Add VM to Redis inventory ('pending' pool)
+      $redis.sadd('vmpooler__pending__' + vm['template'], vm['hostname'])
+      $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone', Time.now)
+      $redis.hset('vmpooler__vm__' + vm['hostname'], 'template', vm['template'])
+
+      # Annotate with creation time, origin template, etc.
+      # Add extraconfig options that can be queried by vmtools
+      configSpec = RbVmomi::VIM.VirtualMachineConfigSpec(
+        annotation: JSON.pretty_generate(
+            name: vm['hostname'],
+            created_by: $config[:vsphere]['username'],
+            base_template: vm['template'],
+            creation_timestamp: Time.now.utc
+        ),
+        extraConfig: [
+            { key: 'guestinfo.hostname',
+              value: vm['hostname']
+            }
+        ]
+      )
+
+      # Choose a clone target
+      if target
+        $clone_target = vsphere.find_least_used_host(target)
+      elsif $config[:config]['clone_target']
+        $clone_target = vsphere.find_least_used_host($config[:config]['clone_target'])
+      end
+
+      # Put the VM in the specified folder and resource pool
+      relocateSpec = RbVmomi::VIM.VirtualMachineRelocateSpec(
+        datastore: vsphere.find_datastore(datastore),
+        host: $clone_target,
+        diskMoveType: :moveChildMostDiskBacking
+      )
+
+      # Create a clone spec
+      spec = RbVmomi::VIM.VirtualMachineCloneSpec(
+        location: relocateSpec,
+        config: configSpec,
+        powerOn: true,
+        template: false
+      )
+
+      # Clone the VM
+      $logger.log('d', "[ ] [#{vm['template']}] '#{vm['hostname']}' is being cloned from '#{vm['template']}'")
+
+      begin
+        start = Time.now
+        vm[vm['template']].CloneVM_Task(
+          folder: vsphere.find_folder(folder),
+          name: vm['hostname'],
+          spec: spec
+        ).wait_for_completion
+        finish = '%.2f' % (Time.now - start)
+
+        $redis.hset('vmpooler__clone__' + Date.today.to_s, vm['template'] + ':' + vm['hostname'], finish)
+        $redis.hset('vmpooler__vm__' + vm['hostname'], 'clone_time', finish)
+
+        $logger.log('s', "[+] [#{vm['template']}] '#{vm['hostname']}' cloned from '#{vm['template']}' in #{finish} seconds")
+      rescue => err
+        $logger.log('s', "[!] [#{vm['template']}] '#{vm['hostname']}' clone failed with an error: #{err}")
+        $redis.srem('vmpooler__pending__' + vm['template'], vm['hostname'])
+        raise
+      end
+
+      $redis.decr('vmpooler__tasks__clone')
+
+      $metrics.timing("clone.#{vm['template']}", finish)
     end
 
     # Destroy a VM
@@ -710,14 +718,7 @@ module Vmpooler
           if $redis.get('vmpooler__tasks__clone').to_i < $config[:config]['task_limit'].to_i
             begin
               $redis.incr('vmpooler__tasks__clone')
-
-              clone_vm(
-                pool['template'],
-                pool['folder'],
-                pool['datastore'],
-                pool['clone_target'],
-                vsphere
-              )
+              clone_vm(pool,vsphere)
             rescue => err
               $logger.log('s', "[!] [#{pool['name']}] clone failed during check_pool with an error: #{err}")
               $redis.decr('vmpooler__tasks__clone')


### PR DESCRIPTION
Previously, the clone_vm method took various VSphere specific parameters e.g.
template folder.  However in order make VMPooler less VSphere specific this
method should just take the pool configuration and then it can determine the
appropriate settings itself.  This commit also moves the threading to a clone_vm
while the actual method which does the work is now _clone_vm as per all other
multithread worker methods in pool_manager.  This commit also updates the spec
tests appropriately.