### PR TITLE
(WIP) (POOLER-50) Remove VM migration code

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -55,7 +55,6 @@ module Vmpooler
 
     def account_for_starting_vm(template, vm)
       backend.sadd('vmpooler__running__' + template, vm)
-      backend.sadd('vmpooler__migrating__' + template, vm)
       backend.hset('vmpooler__active__' + template, vm, Time.now)
       backend.hset('vmpooler__vm__' + vm, 'checkout', Time.now)
 

--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -190,85 +190,9 @@ module Vmpooler
       base
     end
 
-    # Returns an array containing cumulative CPU and memory utilization of a host, and its object reference
-    # Params:
-    # +model+:: CPU arch version to match on
-    # +limit+:: Hard limit for CPU or memory utilization beyond which a host is excluded for deployments
-    def get_host_utilization(host, model=nil, limit=90)
-      if model
-        return nil unless host_has_cpu_model? host, model
-      end
-      return nil if host.runtime.inMaintenanceMode
-      return nil unless host.overallStatus == 'green'
-
-      cpu_utilization = cpu_utilization_for host
-      memory_utilization = memory_utilization_for host
-
-      return nil if cpu_utilization > limit
-      return nil if memory_utilization > limit
-
-      [ cpu_utilization + memory_utilization, host ]
-    end
-
-    def host_has_cpu_model?(host, model)
-       get_host_cpu_arch_version(host) == model
-    end
-
-    def get_host_cpu_arch_version(host)
-      cpu_model = host.hardware.cpuPkg[0].description
-      cpu_model_parts = cpu_model.split()
-      arch_version = cpu_model_parts[4]
-      arch_version
-    end
-
-    def cpu_utilization_for(host)
-      cpu_usage = host.summary.quickStats.overallCpuUsage
-      cpu_size = host.summary.hardware.cpuMhz * host.summary.hardware.numCpuCores
-      (cpu_usage.to_f / cpu_size.to_f) * 100
-    end
-
-    def memory_utilization_for(host)
-      memory_usage = host.summary.quickStats.overallMemoryUsage
-      memory_size = host.summary.hardware.memorySize / 1024 / 1024
-      (memory_usage.to_f / memory_size.to_f) * 100
-    end
-
-    def find_least_used_host(cluster)
-      ensure_connected @connection, $credentials
-
-      cluster_object = find_cluster(cluster)
-      target_hosts = get_cluster_host_utilization(cluster_object)
-      least_used_host = target_hosts.sort[0][1]
-      least_used_host
-    end
-
     def find_cluster(cluster)
       datacenter = @connection.serviceInstance.find_datacenter
       datacenter.hostFolder.children.find { |cluster_object| cluster_object.name == cluster }
-    end
-
-    def get_cluster_host_utilization(cluster)
-      cluster_hosts = []
-      cluster.host.each do |host|
-        host_usage = get_host_utilization(host)
-        cluster_hosts << host_usage if host_usage
-      end
-      cluster_hosts
-    end
-
-    def find_least_used_compatible_host(vm)
-      ensure_connected @connection, $credentials
-
-      source_host = vm.summary.runtime.host
-      model = get_host_cpu_arch_version(source_host)
-      cluster = source_host.parent
-      target_hosts = []
-      cluster.host.each do |host|
-        host_usage = get_host_utilization(host, model)
-        target_hosts << host_usage if host_usage
-      end
-      target_host = target_hosts.sort[0][1]
-      [target_host, target_host.name]
     end
 
     def find_pool(poolname)
@@ -403,11 +327,6 @@ module Vmpooler
       end
 
       snapshot
-    end
-
-    def migrate_vm_host(vm, host)
-      relospec = RbVmomi::VIM.VirtualMachineRelocateSpec(host: host)
-      vm.RelocateVM_Task(spec: relospec).wait_for_completion
     end
 
     def close

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -90,17 +90,6 @@ def create_discovered_vm(name, pool, redis_handle = nil)
   redis_db.sadd("vmpooler__discovered__#{pool}", name)
 end
 
-def create_migrating_vm(name, pool, redis_handle = nil)
-  redis_db = redis_handle ? redis_handle : redis
-  redis_db.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
-  redis_db.sadd("vmpooler__migrating__#{pool}", name)
-end
-
-def add_vm_to_migration_set(name, redis_handle = nil)
-  redis_db = redis_handle ? redis_handle : redis
-  redis_db.sadd('vmpooler__migration', name)
-end
-
 def fetch_vm(vm)
   redis.hgetall("vmpooler__vm__#{vm}")
 end

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -247,13 +247,6 @@
 #     a separator.
 #     (optional; default: '')
 #
-#   - migration_limit
-#     When set to any value greater than 0 enable VM migration at checkout.
-#     When enabled this capability will evaluate a VM for migration when it is requested
-#     in an effort to maintain a more even distribution of load across compute resources.
-#     The migration_limit ensures that no more than n migrations will be evaluated at any one time
-#     and greatly reduces the possibilty of VMs ending up bunched together on a particular host.
-#
 #  - max_tries
 #    Set the max number of times a connection should retry in vsphere helper.
 #    This optional setting allows a user to dial in retry limits to


### PR DESCRIPTION
(WIP)

The migrate_vm code introduced in commit 705e5d26d87a3e29a9483bf7 caused errors
and has since been found to be problematic.  This commit removes the changes
introduced as part of PR 167 that peratin to the migrate_vm code.