### PR TITLE
Remove duplicate of metrics.connect.open

### DIFF
--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -15,7 +15,6 @@ module Vmpooler
     def ensure_connected(connection, credentials)
       connection.serviceInstance.CurrentTime
     rescue
-      $metrics.increment("connect.open")
       connect_to_vsphere $credentials
     end
 


### PR DESCRIPTION
This commit removes a duplicate increment of the metrics.connect.open count. Without this change two connections will be reported when one is made.

This should address #195 