### PR TITLE
(maint) Fix credentials in vsphere_helper

### DIFF
--- a/lib/vmpooler/vsphere_helper.rb
+++ b/lib/vmpooler/vsphere_helper.rb
@@ -15,7 +15,7 @@ module Vmpooler
     def ensure_connected(connection, credentials)
       connection.serviceInstance.CurrentTime
     rescue
-      connect_to_vsphere $credentials
+      connect_to_vsphere @credentials
     end
 
     def connect_to_vsphere(credentials)


### PR DESCRIPTION
In commit 03ad7bfa468 the global variables for credentials was change to an
instance variable however one reference was missed.  This commit fixes this
omission.