### PR TITLE
(maint) Emit console messages when debugging is enabled

### DIFF
--- a/lib/vmpooler/logger.rb
+++ b/lib/vmpooler/logger.rb
@@ -12,6 +12,8 @@ module Vmpooler
       time = Time.new
       stamp = time.strftime('%Y-%m-%d %H:%M:%S')
 
+      puts "[#{stamp}] #{string}" if ENV['VMPOOLER_DEBUG']
+
       open(@file, 'a') do |f|
         f.puts "[#{stamp}] #{string}"
       end


### PR DESCRIPTION
Previously all log messages may be written to a text file, however during
development or debugging it is also useful if the log messages are written to
the console.  This commit changes the logger class to emit messages to the
console, via `puts`, if the `VMPOOLER_DEBUG` environment variable is set.