### PR TITLE
(maint) Pin rack to 1.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,9 @@ else
 end
 
 gem 'puma', '>= 3.6.0'
-gem 'rack', '>= 1.6'
+# Rack 2.x requires ruby 2.2 or above.
+# As VMPooler should work in older jruby, we need to be Ruby 1.9.3 compatible.
+gem 'rack', '~> 1.6'
 gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
 gem 'redis', '>= 3.2'


### PR DESCRIPTION
Rack was updated recently and 2.x requires ruby 2.2 or above. As VMPooler should
work in older jruby, we need to be Ruby 1.9.3 compatible.  This commit pins
the rack gem to 1.x.