### PR TITLE
Refactor get_cluster_host_utilization method

### DIFF
--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -2198,7 +2198,7 @@ EOT
       end
 
       it 'should raise error' do
-        expect{subject.find_least_used_vpshere_compatible_host(vm)}.to raise_error(NoMethodError,/undefined method/)
+        expect{subject.find_least_used_vpshere_compatible_host(vm)}.to raise_error(/There is no host candidate in vcenter that meets all the required conditions/)
       end
     end
 
@@ -2238,7 +2238,7 @@ EOT
       end
 
       it 'should raise error' do
-        expect{subject.find_least_used_vpshere_compatible_host(vm)}.to raise_error(NoMethodError,/undefined method/)
+        expect{subject.find_least_used_vpshere_compatible_host(vm)}.to raise_error(/There is no host candidate in vcenter that meets all the required conditions/)
       end
     end
 


### PR DESCRIPTION
The same method logic was being used in two places but only one was calling the method
get_cluster_host_utilization, so this refactors it to use the method for both.
The method could also return an empty array and the subsequent line would try
to .sort[0][1] which would return undefined method [] for nil:NilClass in that
case. The return value is now checked and an exception raised