### PR TITLE
Adding support for multiple vsphere providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ The following YAML configuration sets up two pools, `debian-7-i386` and `debian-
     provider: vsphere
 ```
 
-See the provided YAML configuration example, [vmpooler.yaml.example](vmpooler.yaml.example), for additional configuration options and parameters.
+See the provided YAML configuration example, [vmpooler.yaml.example](vmpooler.yaml.example), for additional configuration options and parameters or for supporting multiple providers.
 
 ### Running via Docker
 

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -35,6 +35,7 @@ module Vmpooler
           end
         end
 
+        # name of the provider class
         def name
           'vsphere'
         end

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -32,12 +32,34 @@
 #   - insecure
 #     Whether to ignore any HTTPS negotiation errors (e.g. untrusted self-signed certificates)
 #     (optional: default true)
+#
+#   - provider_class
+#     For multiple providers, specify one of the supported backing services (vsphere or dummy)
+#     (optional: will default to it's parent :key: name eg. 'vsphere')
+#
 # Example:
 
   :vsphere:
     server: 'vsphere.company.com'
     username: 'vmpooler'
     password: 'swimsw1msw!m'
+
+# If you want to support more than one provider with different parameters (server, username or passwords) you have to specify the
+# backing service in the provider_class configuration parameter for example 'vsphere' or 'dummy'. Each pool can specify
+# the provider to use.
+#
+# Multiple providers example:
+
+  :vsphere-pdx:
+    server: 'vsphere.pdx.company.com'
+    username: 'vmpooler-pdx'
+    password: 'swimsw1msw!m'
+    provider_class: 'vsphere'
+  :vsphere-bfs:
+    server: 'vsphere.bfs.company.com'
+    username: 'vmpooler-bfs'
+    password: 'swimsw1msw!m'
+    provider_class: 'vsphere'
 
 # :dummy:
 #
@@ -417,6 +439,8 @@
 #     The name of the VM provider which manage this pool.  This should match
 #     a name in the :providers: section above e.g. vsphere
 #     (required; will default to vsphere for backwards compatibility)
+#     If you have more than one provider, this is where you would choose which
+#     one to use for this pool
 #
 #   - clone_target
 #     Per-pool option to override the global 'clone_target' cluster.


### PR DESCRIPTION
Refactoring the vmpooler.yaml format to support multiple providers.
The second level key under :providers: is a unique key name that
represents a provider that can be referred in the pool's parameter
called provider. The code is still backward compatible to support
the :vsphere: and :dummy: keys but in reality if you have more than
one vsphere configuration you would give them a different name. For
example :vsphere-pdx: and :vsphere-bfs: and the actual provider
class would be specified as a parameter called 'provider_class'.
See tests and examples for more information.