### PR TITLE
Update find_least_used_compatible_host to specify pool

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -490,7 +490,7 @@ module Vmpooler
           return
         else
           $redis.sadd('vmpooler__migration', vm_name)
-          host_name = provider.find_least_used_compatible_host(vm_name)
+          host_name = provider.find_least_used_compatible_host(pool_name, vm_name)
           if host_name == parent_host_name
             $logger.log('s', "[ ] [#{pool_name}] No migration required for '#{vm_name}' running on #{parent_host_name}")
           else

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1619,7 +1619,7 @@ EOT
 
       context 'and host to migrate to is the same as the current host' do
         before(:each) do
-          expect(provider).to receive(:find_least_used_compatible_host).with(vm).and_return(vm_parent_hostname)
+          expect(provider).to receive(:find_least_used_compatible_host).with(pool, vm).and_return(vm_parent_hostname)
         end
 
         it "should not migrate the VM" do
@@ -1648,7 +1648,7 @@ EOT
       context 'and host to migrate to different to the current host' do
         let(:vm_new_hostname) { 'new_hostname' }
         before(:each) do
-          expect(provider).to receive(:find_least_used_compatible_host).with(vm).and_return(vm_new_hostname)
+          expect(provider).to receive(:find_least_used_compatible_host).with(pool, vm).and_return(vm_new_hostname)
           expect(subject).to receive(:migrate_vm_and_record_timing).with(vm, pool, vm_parent_hostname, vm_new_hostname, provider).and_return('1.00')
         end
 


### PR DESCRIPTION
This commit updates find_least_used_compatible_host method to specify
the pool name when evaluating a VM for migration. Without this change VM
migration fails with a wrong number of arguments error. Pool_manager
test references are updated to reflect the change.