### PR TITLE
(GH-230) Dynamically load VM Providers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem 'puma', '>= 3.6.0'
 gem 'rack', '~> 1.6'
 gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
+if RUBY_VERSION =~ /^1\.9\./
+  gem 'nokogiri', '< 1.7.0'
+end
 gem 'redis', '>= 3.2'
 gem 'sinatra', '>= 1.4'
 gem 'net-ldap', '<= 0.12.1' # keep compatibility w/ jruby & mri-1.9.3

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -735,21 +735,20 @@ module Vmpooler
       raise
     end
 
-    # create a provider object based on the providers/*.rb class that implements providers/base.rb
-    # provider_class: needs to match a provider class in providers/*.rb ie Vmpooler::PoolManager::Provider::X
-    # provider_name: should be a unique provider name
+    # Create a provider object, usually based on the providers/*.rb class, that implements providers/base.rb
+    # provider_class: Needs to match a class in the Vmpooler::PoolManager::Provider namespace. This is
+    #                 either as a gem in the LOADPATH or in providers/*.rb ie Vmpooler::PoolManager::Provider::X
+    # provider_name:  Should be a unique provider name
     #
     # returns an object Vmpooler::PoolManager::Provider::*
     # or raises an error if the class does not exist
     def create_provider_object(config, logger, metrics, provider_class, provider_name, options)
-      case provider_class
-      when 'vsphere'
-        Vmpooler::PoolManager::Provider::VSphere.new(config, logger, metrics, provider_name, options)
-      when 'dummy'
-        Vmpooler::PoolManager::Provider::Dummy.new(config, logger, metrics, provider_name, options)
-      else
-        raise("Provider '#{provider_class}' is unknown for pool with provider '#{provider_name}'")
+      provider_klass = Vmpooler::PoolManager::Provider
+      provider_klass.constants.each do |classname|
+        next unless classname.to_s.casecmp(provider_class) == 0
+        return provider_klass.const_get(classname).new(config, logger, metrics, provider_name, options)
       end
+      raise("Provider '#{provider_class}' is unknown for pool with provider name '#{provider_name}'") if provider.nil?
     end
 
     def execute!(maxloop = 0, loop_delay = 1)


### PR DESCRIPTION
Previously, a static list was used to instantiate VM Pooler Provider objects.
This commit changes the loader to instead interrogate the available clases in
the Vmpooler::PoolManager::Provider namespace and then instantiate from there.

This means class names are not case sensitive and that VM Providers can now be
dynamically loaded from other sources such as gems in the LOADPATH.  No tests
were added as this behaviour is exercised in the execute! tests already.