### PR TITLE
(maint) Update template delta script for moved vsphere credentials

### DIFF
--- a/scripts/create_template_deltas.rb
+++ b/scripts/create_template_deltas.rb
@@ -22,9 +22,9 @@ def create_template_deltas( folder )
   abort 'No config file (./vmpooler.yaml or ~/.vmpooler) found!' unless config
 
   vim = RbVmomi::VIM.connect(
-    :host     => config[ :vsphere ][ "server" ],
-    :user     => config[ :vsphere ][ "username" ],
-    :password => config[ :vsphere ][ "password" ],
+    :host     => config[ :providers ][ :vsphere ][ "server" ],
+    :user     => config[ :providers ][ :vsphere ][ "username" ],
+    :password => config[ :providers ][ :vsphere ][ "password" ],
     :ssl      => true,
     :insecure => true,
   ) or abort "Unable to connect to #{config[ :vsphere ][ "server" ]}!"


### PR DESCRIPTION
The vmpooler.yaml file has been reorganized a bit and now nests the
vsphere credentials within a "providers" class. This tweak is needed
to keep the template delta script working.