### PR TITLE
(POOLER-89) Identify when config issue is present

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -545,6 +545,7 @@ module Vmpooler
           end
           return nil if host.runtime.inMaintenanceMode
           return nil unless host.overallStatus == 'green'
+          return nil unless host.configIssue.empty?
 
           cpu_utilization = cpu_utilization_for host
           memory_utilization = memory_utilization_for host

--- a/spec/rbvmomi_helper.rb
+++ b/spec/rbvmomi_helper.rb
@@ -83,7 +83,9 @@ MockHostSystem = Struct.new(
   # From HostSystem
   :capability, :config, :configManager, :datastore, :datastoreBrowser, :hardware, :network, :runtime, :summary, :systemResources, :vm,
   # From ManagedEntity
-  :overallStatus, :name, :parent
+  :overallStatus, :name, :parent,
+  # From ManagedObject
+  :configIssue
 )
 
 MockPropertyCollector = Struct.new(
@@ -507,6 +509,7 @@ def mock_RbVmomi_VIM_HostSystem(options = {})
   options[:overall_cpu_usage]    = 1 if options[:overall_cpu_usage].nil?
   options[:overall_memory_usage] = 1 if options[:overall_memory_usage].nil?
   options[:name]                 = 'HOST' + rand(65536).to_s if options[:name].nil?
+  options[:config_issue]         = [] if options[:config_issue].nil?
 
   mock = MockHostSystem.new()
   mock.name = options[:name]
@@ -527,6 +530,7 @@ def mock_RbVmomi_VIM_HostSystem(options = {})
 
   mock.runtime.inMaintenanceMode = options[:maintenance_mode]
   mock.overallStatus = options[:overall_status]
+  mock.configIssue = options[:config_issue]
 
   mock.summary.hardware.memorySize = options[:memory_size]
   mock.hardware.memorySize = options[:memory_size]

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -1903,6 +1903,16 @@ EOT
       end
     end
 
+    context "host with configuration issue" do
+      let(:host) { mock_RbVmomi_VIM_HostSystem({
+        :config_issue => 'No quickstats',
+      })
+      }
+      it 'should return nil' do
+        expect(subject.get_host_utilization(host,model,limit)).to be_nil
+      end
+    end
+
     # CPU utilization
     context "host which exceeds limit in CPU utilization" do
       let(:host) { mock_RbVmomi_VIM_HostSystem({


### PR DESCRIPTION
This commit adds vmpooler inspection of configuration issues to host
selection. Specifically, configIssue is checked, which should allow an
issue like quickstats not being reported to be identified even when the
alarm will not trigger. Without this change a host will continue to be
used if quickstats are not reported when alarms are not triggered
because of this condition, which results in a single host being the
target for all deploys and migrations, overloading the host and causing
its VMs to have degraded performance.