### PR TITLE
(GH-226) Respond quickly to VMs being consumed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,14 +12,33 @@ gem 'puma', '>= 3.6.0'
 gem 'rack', '~> 1.6'
 gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
-if RUBY_VERSION =~ /^1\.9\./
-  gem 'nokogiri', '< 1.7.0'
-end
-gem 'redis', '>= 3.2'
 gem 'sinatra', '>= 1.4'
 gem 'net-ldap', '<= 0.12.1' # keep compatibility w/ jruby & mri-1.9.3
 gem 'statsd-ruby', '>= 1.3.0', :require => 'statsd'
 gem 'connection_pool', '>= 2.2.1'
+
+# Pin gems against Ruby version
+# Note we can't use platform restrictions easily so use
+# lowest version range any platform
+# ----
+# nokogiri
+# redis
+if RUBY_VERSION =~ /^1\.9\./
+  gem 'nokogiri', '~> 1.6.0'
+  gem 'redis', '~> 3.0'
+elsif RUBY_VERSION =~ /^2\.[0]/
+  gem 'nokogiri', '~> 1.6.0'
+  gem 'redis', '~> 3.0'
+elsif RUBY_VERSION =~ /^2\.[1]/
+  gem 'nokogiri', '~> 1.7.0'
+  gem 'redis', '~> 3.0'
+elsif RUBY_VERSION =~ /^2\.2\.[01]/
+  gem 'nokogiri', "~> 1.7"
+  gem 'redis', '~> 3.0'
+else
+  gem 'nokogiri', "~> 1.7"
+  gem 'redis', '>= 3.2'
+end
 
 # Test deps
 group :test do


### PR DESCRIPTION
Previously in commit 9b0e55f the looping period was changed from a static
number to a dynamic one depending on load, however this meant that the operation
to refill a pool was slowed down somewhat.  While not a problem under normal
loads, when a pool was quickly consumed, the pool manager may not respond
quickly enough to refill the pool.  This commit:

- Changes the sleep method, to us a helper sleep method that will wakeup
  periodically and evaluate other wakeup events.  This could be used later to
  exit sleep loops when pooler is shutting down to stop blocking threads
- By default the wakeup_period is set to the minimum pool check loop time, thus
  emulating the behaviour prior to commit 9b0e55f
- Adds tests for the behaviour