### PR TITLE
Updated Vagrant box and associated docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,11 @@ cp vmpooler.yaml.dummy-example vmpooler.yaml
 sudo yum -y install redis
 sudo systemctl start redis
 
+# Optional: Choose your ruby version or use jruby
+# ruby 2.4.x is used by default
+rvm list
+rvm use jruby-9.1.7.0
+
 gem install bundler
 bundle install
 bundle exec ruby vmpooler

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 # vim: autoindent tabstop=2 shiftwidth=2 expandtab softtabstop=2 filetype=ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "genebean/centos-7-rvm-221"
+  config.vm.box = "genebean/centos-7-rvm-multi"
   config.vm.network "forwarded_port", guest: 4567, host: 4567
   config.vm.network "forwarded_port", guest: 8080, host: 8080
   config.vm.provision "shell", inline: <<-SCRIPT


### PR DESCRIPTION
This move vmpooler to my newer Vagrant box and also documents how to run directly in Vagrant using different versions of ruby.