### PR TITLE
Fix no implicit conversion to rational from nil

### DIFF
--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -324,6 +324,7 @@ EOT
         before(:each) do
           host['boottime'] = nil
           host['powerstate'] = 'PoweredOff'
+          ttl = 1440
         end
 
         it 'should move the VM to the completed queue' do

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -322,6 +322,7 @@ EOT
 
       context 'is turned off' do
         before(:each) do
+          host['boottime'] = nil
           host['powerstate'] = 'PoweredOff'
         end
 


### PR DESCRIPTION
Before this change if the boottime was nil, the check_ready
loop would exit on Time.now - host['boottime'] with a TypeError
in jruby. The boottime is nil when the power is Off so moving that check
earlier should catch that bug.