### PR TITLE
Allow user to specify a configuration file in VMPOOLER_CONFIG_FILE variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 Gemfile.lock
 Gemfile.local
 vendor
-vmpooler.yaml
+/vmpooler.yaml
 .bundle
 coverage

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -62,17 +62,25 @@ C:\vmpooler > $ENV:VMPOOLER_DEBUG = 'true'
 
 ### `VMPOOLER_CONFIG`
 
-When `VMPOOLER_CONFIG` is set, vmpooler will read its configuration from the content of the environment variable instead of from the `vmpooler.yaml` configuration file.
+When `VMPOOLER_CONFIG` is set, vmpooler will read its configuration from the content of the environment variable.
 
-Note that this variable does not point a different configuration file, but stores the contents of a configuration file.
+Note that this variable does not point to a different configuration file, but stores the contents of a configuration file. You may use `VMPOOLER_CONFIG_FILE` instead to specify a filename.
+
+
+### `VMPOOLER_CONFIG_FILE`
+
+When `VMPOOLER_CONFIG_FILE` is set, vmpooler will read its configuration from the file specified in the environment variable.
+
+Note that this variable points to a different configuration file, unlike `VMPOOLER_CONFIG`.
 
 
 ## Setup vmpooler Configuration
 
-You can either create a `vmpooler.yaml` file or set the `VMPOOLER_CONFIG` environment variable with the equivalent content.
+You can create a `vmpooler.yaml` file, set the `VMPOOLER_CONFIG` environment variable with the equivalent content, or set the `VMPOOLER_CONFIG_FILE` environment variable with the name of another configuration file to use. `VMPOOLER_CONFIG` takes precedence over `VMPOOLER_CONFIG_FILE`.
 
 Example minimal configuration file:
 ```yaml
+
 ---
 :providers:
   :dummy:

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -21,16 +21,18 @@ module Vmpooler
   end
 
   def self.config(filepath = 'vmpooler.yaml')
-    parsed_config = {}
+    # Take the config either from an ENV config variable or from a config file
+    config_string = ENV['VMPOOLER_CONFIG'] || begin
+      # Take the name of the config file either from an ENV variable or from the filepath argument
+	    config_file = ENV['VMPOOLER_CONFIG_FILE'] || filepath
 
-    if ENV['VMPOOLER_CONFIG']
-      # Load configuration from ENV
-      parsed_config = YAML.safe_load(ENV['VMPOOLER_CONFIG'])
-    else
-      # Load the configuration file from disk
-      config_file = File.expand_path(filepath)
-      parsed_config = YAML.load_file(config_file)
+      # Return the contents of the config file
+	    File.read(File.expand_path(config_file))
     end
+
+    # Parse the YAML config into a Hash
+    # Whitelist the Symbol class
+    parsed_config = YAML.safe_load(config_string, [Symbol])
 
     # Bail out if someone attempts to start vmpooler with dummy authentication
     # without enbaling debug mode.

--- a/spec/fixtures/vmpooler.yaml
+++ b/spec/fixtures/vmpooler.yaml
@@ -1,0 +1,41 @@
+---
+:providers:
+  :dummy:
+
+:redis:
+  server: 'localhost'
+
+:auth:
+   provider: dummy
+
+:tagfilter:
+  url: '(.*)\/'
+
+:config:
+  site_name: 'vmpooler'
+  # Need to change this on Windows
+  logfile: '/var/log/vmpooler.log'
+  task_limit: 10
+  timeout: 15
+  vm_checktime: 15
+  vm_lifetime: 12
+  vm_lifetime_auth: 24
+  allowed_tags:
+    - 'created_by'
+    - 'project'
+  domain: 'company.com'
+  prefix: 'poolvm-'
+
+# Uncomment the lines below to suppress metrics to STDOUT
+# :statsd:
+#   server: 'localhost'
+#   prefix: 'vmpooler'
+#   port: 8125
+
+:pools:
+  - name: 'pool01'
+    size: 5
+    provider: dummy
+  - name: 'pool02'
+    size: 5
+    provider: dummy

--- a/spec/fixtures/vmpooler2.yaml
+++ b/spec/fixtures/vmpooler2.yaml
@@ -1,0 +1,41 @@
+---
+:providers:
+  :dummy:
+
+:redis:
+  server: 'localhost'
+
+:auth:
+   provider: dummy
+
+:tagfilter:
+  url: '(.*)\/'
+
+:config:
+  site_name: 'vmpooler'
+  # Need to change this on Windows
+  logfile: '/var/log/vmpooler.log'
+  task_limit: 10
+  timeout: 15
+  vm_checktime: 15
+  vm_lifetime: 12
+  vm_lifetime_auth: 24
+  allowed_tags:
+    - 'created_by'
+    - 'project'
+  domain: 'company.com'
+  prefix: 'poolvm-'
+
+# Uncomment the lines below to suppress metrics to STDOUT
+# :statsd:
+#   server: 'localhost'
+#   prefix: 'vmpooler'
+#   port: 8125
+
+:pools:
+  - name: 'pool03'
+    size: 5
+    provider: dummy
+  - name: 'pool04'
+    size: 5
+    provider: dummy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,3 +9,11 @@ require 'rspec'
 require 'vmpooler'
 require 'redis'
 require 'vmpooler/statsd'
+
+def project_root_dir
+  File.dirname(File.dirname(__FILE__))
+end
+
+def fixtures_dir
+  File.join(project_root_dir, 'spec', 'fixtures')
+end

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -820,7 +820,7 @@ EOT
 
       it 'should honor the insecure setting' do
         pending('Resolution of issue https://github.com/puppetlabs/vmpooler/issues/207')
-        config[:vsphere][:insecure] = false
+        config[:providers][:vsphere][:insecure] = false
 
         expect(RbVmomi::VIM).to receive(:connect).with({
           :host     => credentials['server'],

--- a/spec/unit/vmpooler_spec.rb
+++ b/spec/unit/vmpooler_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'Vmpooler' do
+  describe '.config' do
+    let(:config_file) { File.join(fixtures_dir, 'vmpooler2.yaml') }
+    let(:config) { YAML.load_file(config_file) }
+
+    before(:each) do
+      ENV['VMPOOLER_DEBUG'] = 'true'
+      ENV['VMPOOLER_CONFIG_FILE'] = nil
+      ENV['VMPOOLER_CONFIG'] = nil
+    end
+
+    context 'when no config is given' do
+      it 'defaults to vmpooler.yaml' do
+        default_config_file = File.join(fixtures_dir, 'vmpooler.yaml')
+        default_config = YAML.load_file(default_config_file)
+
+        Dir.chdir(fixtures_dir) do
+          expect(Vmpooler.config[:pools]).to eq(default_config[:pools])
+        end
+      end
+    end
+
+    context 'when config variable is set' do
+      it 'should use the config' do
+        ENV['VMPOOLER_CONFIG'] = config.to_yaml
+        expect(Vmpooler.config[:pools]).to eq(config[:pools])
+      end
+    end
+
+    context 'when config file is set' do
+      it 'should use the file' do
+        ENV['VMPOOLER_CONFIG_FILE'] = config_file
+        expect(Vmpooler.config[:pools]).to eq(config[:pools])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Previously, there were two ways to configure Vmpooler, either by
changing the contents of vmpooler.yaml or by assigning the raw YAML
to the VMPOOLER_CONFIG environment variable. This commit adds a new
environment variable called VMPOOLER_CONFIG_FILE that can be assigned
the name of a config file to use. Also fixes #240 by whitelisting the
Symbol class when calling YAML.safe_load in Vmpooler.config.