### PR TITLE
Update jruby version for travis to 9.1.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     - rvm: 2.3.3
       env: "CHECK=test"
 
-    - rvm: jruby-1.7.13
+    - rvm: jruby-9.1.13.0
       env: "CHECK=test"
 
   # Remove the allow_failures section once

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-if RUBY_VERSION =~ /^1\.9\./
-  gem 'json', '~> 1.8'
-else
-  gem 'json', '>= 1.8'
-end
-
+gem 'json', '>= 1.8'
 gem 'puma', '>= 3.6.0'
 # Rack 2.x requires ruby 2.2 or above.
 # As VMPooler should work in older jruby, we need to be Ruby 1.9.3 compatible.
@@ -23,13 +18,7 @@ gem 'connection_pool', '>= 2.2.1'
 # ----
 # nokogiri
 # redis
-if RUBY_VERSION =~ /^1\.9\./
-  gem 'nokogiri', '~> 1.6.0'
-  gem 'redis', '~> 3.0'
-elsif RUBY_VERSION =~ /^2\.[0]/
-  gem 'nokogiri', '~> 1.6.0'
-  gem 'redis', '~> 3.0'
-elsif RUBY_VERSION =~ /^2\.[1]/
+if RUBY_VERSION =~ /^2\.[1]/
   gem 'nokogiri', '~> 1.7.0'
   gem 'redis', '~> 3.0'
 elsif RUBY_VERSION =~ /^2\.2\.[01]/


### PR DESCRIPTION
This commit updates travis configuration to replace jruby 1.7.13 with 9.1.13.0. Without this change the jruby version tested is out of date and does not support features like safe_load, which affects issue #243.