### PR TITLE
Identify when ESXi host quickstats do not return

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -625,8 +625,11 @@ module Vmpooler
           cpu_utilization = cpu_utilization_for host
           memory_utilization = memory_utilization_for host
 
-          return nil if cpu_utilization == 0
-          return nil if memory_utilization == 0
+          return nil if cpu_utilization.nil?
+          return nil if cpu_utilization == 0.0
+          return nil if memory_utilization.nil?
+          return nil if memory_utilization == 0.0
+
           return nil if cpu_utilization > limit
           return nil if memory_utilization > limit
 
@@ -646,12 +649,14 @@ module Vmpooler
 
         def cpu_utilization_for(host)
           cpu_usage = host.summary.quickStats.overallCpuUsage
+          return nil if cpu_usage.nil?
           cpu_size = host.summary.hardware.cpuMhz * host.summary.hardware.numCpuCores
           (cpu_usage.to_f / cpu_size.to_f) * 100
         end
 
         def memory_utilization_for(host)
           memory_usage = host.summary.quickStats.overallMemoryUsage
+          return nil if memory_usage.nil?
           memory_size = host.summary.hardware.memorySize / 1024 / 1024
           (memory_usage.to_f / memory_size.to_f) * 100
         end

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -1772,6 +1772,24 @@ EOT
         expect(subject.get_host_utilization(host,model,limit)[1]).to eq(host)
       end
     end
+
+    context 'host with no quickstats' do
+      let(:host) { mock_RbVmomi_VIM_HostSystem({
+        :cpu_speed => 100,
+        :num_cores_per_cpu => 1,
+        :num_cpu => 1,
+        :memory_size => 100.0 * 1024 * 1024
+        })
+      }
+      before(:each) do
+        host.summary.quickStats.overallCpuUsage = nil
+      end
+
+      it 'should return nil' do
+        result = subject.get_host_utilization(host,model,limit)
+        expect(result).to be nil
+      end
+    end
   end
 
   describe '#host_has_cpu_model?' do


### PR DESCRIPTION
This commit updates cpu_utilization_for and memory_utilization_for to detect when quickstats are not present. Without this change a nil result is transformed to 0, which is perceived as a host that has no utilization.