### PR TITLE
(maint) Add the last boot time for each pool

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -205,17 +205,19 @@ module Vmpooler
       result[:pools] = {} unless views and not views.include?("pools")
       pools.each do |pool|
         # REMIND: move this out of the API and into the back-end
-        ready   = backend.scard('vmpooler__ready__' + pool['name']).to_i
-        running = backend.scard('vmpooler__running__' + pool['name']).to_i
-        pending = backend.scard('vmpooler__pending__' + pool['name']).to_i
-        max     = pool['size']
-        aka     = pool['alias']
+        ready    = backend.scard('vmpooler__ready__' + pool['name']).to_i
+        running  = backend.scard('vmpooler__running__' + pool['name']).to_i
+        pending  = backend.scard('vmpooler__pending__' + pool['name']).to_i
+        max      = pool['size']
+        lastBoot = backend.hget('vmpooler__lastboot',pool['name']).to_s
+        aka      = pool['alias']
 
         result[:pools][pool['name']] = {
-          ready:   ready,
-          running: running,
-          pending: pending,
-          max:     max
+          ready:    ready,
+          running:  running,
+          pending:  pending,
+          max:      max,
+          lastBoot: lastBoot
         }
 
         if aka

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -33,7 +33,7 @@ module Vmpooler
         begin
           _check_pending_vm(vm, pool, timeout, provider)
         rescue => err
-          $logger.log('s', "[!] [#{pool}] '#{vm}' errored while checking a pending vm : #{err}")
+          $logger.log('s', "[!] [#{pool}] '#{vm}' #{timeout} #{provider} errored while checking a pending vm : #{err}")
           fail_pending_vm(vm, pool, timeout)
           raise
         end
@@ -89,7 +89,10 @@ module Vmpooler
         finish = format('%.2f', Time.now - Time.parse(clone_time)) if clone_time
 
         $redis.smove('vmpooler__pending__' + pool, 'vmpooler__ready__' + pool, vm)
-        $redis.hset('vmpooler__boot__' + Date.today.to_s, pool + ':' + vm, finish)
+        $redis.hset('vmpooler__boot__' + Date.today.to_s, pool + ':' + vm, finish) # maybe remove as this is never used by vmpooler itself?
+
+        # last boot time is displayed in API, and used by alarming script
+        $redis.hset('vmpooler__lastboot', pool, Time.now)
 
         $logger.log('s', "[>] [#{pool}] '#{vm}' moved from 'pending' to 'ready' queue")
       end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -222,6 +222,12 @@ EOT
         redis.hset("vmpooler__vm__#{vm}", 'clone','iamnotparsable_asdate')
         expect{subject.move_pending_vm_to_ready(vm, pool, host)}.to raise_error(/iamnotparsable_asdate/)
       end
+
+      it 'should save the last boot time' do
+        expect(redis.hget('vmpooler__lastboot', pool)).to be(nil)
+        subject.move_pending_vm_to_ready(vm, pool, host)
+        expect(redis.hget('vmpooler__lastboot', pool)).to_not be(nil)
+      end
     end
   end
 


### PR DESCRIPTION
This commit add a redis hash where there is one key per pool, and the
stored value is the last time a VM was booted e.g. the last time
a VM went from 'pending' to 'ready'. This is also displayed in the
API as lastBoot:'2018-03-23 17:43:39 +0000'. The data can then be
used by any external system, in this case our alarming system.