### PR TITLE
Add dockerfile without redis

### DIFF
--- a/Dockerfile-aio
+++ b/Dockerfile-aio
@@ -19,10 +19,14 @@ RUN bundle install --system
 
 RUN ln -s /opt/jruby/bin/jruby /usr/bin/jruby
 
+RUN echo "deb http://httpredir.debian.org/debian jessie main" >/etc/apt/sources.list.d/jessie-main.list
+RUN apt-get update && apt-get install -y redis-server && rm -rf /var/lib/apt/lists/*
+
 COPY . /var/lib/vmpooler
 
 ENV VMPOOLER_LOG /var/log/vmpooler.log
 CMD \
-    /var/lib/vmpooler/scripts/vmpooler_init.sh start \
+    /etc/init.d/redis-server start \
+    && /var/lib/vmpooler/scripts/vmpooler_init.sh start \
     && while [ ! -f ${VMPOOLER_LOG} ]; do sleep 1; done ; \
     tail -f ${VMPOOLER_LOG}


### PR DESCRIPTION
This commit adds a dockerfile to install vmpooler without a local redis installation. Without this change the dockerfile provided assumes a local redis instance will be running. The dockerfile with redis is retained as 'Dockerfile-aio'. Additionally, the directory '/var/log/vmpooler' is no longer created since vmpooler uses '/var/log/vmpooler.log'.