### PR TITLE
(POOLER-101) Update nokogiri and net-ldap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,24 +8,21 @@ gem 'rack', '~> 1.6'
 gem 'rake', '>= 10.4'
 gem 'rbvmomi', '>= 1.8'
 gem 'sinatra', '>= 1.4'
-gem 'net-ldap', '<= 0.12.1' # keep compatibility w/ jruby & mri-1.9.3
+gem 'net-ldap', '>= 0.16.1'
 gem 'statsd-ruby', '>= 1.3.0', :require => 'statsd'
 gem 'connection_pool', '>= 2.2.1'
+gem 'nokogiri', '>= 1.8.2'
 
 # Pin gems against Ruby version
 # Note we can't use platform restrictions easily so use
 # lowest version range any platform
 # ----
-# nokogiri
 # redis
 if RUBY_VERSION =~ /^2\.[1]/
-  gem 'nokogiri', '~> 1.7.0'
   gem 'redis', '~> 3.0'
 elsif RUBY_VERSION =~ /^2\.2\.[01]/
-  gem 'nokogiri', "~> 1.7"
   gem 'redis', '~> 3.0'
 else
-  gem 'nokogiri', "~> 1.7"
   gem 'redis', '>= 3.2'
 end
 


### PR DESCRIPTION
This commit updates nokogiri and net-ldap to versions that have fixed known vulnerabilities. Without this change vmpooler requires versions of each gem that contain known vulnerabilities.