### PR TITLE
Add support for setting redis port and password

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -86,8 +86,8 @@ module Vmpooler
     parsed_config
   end
 
-  def self.new_redis(host = 'localhost')
-    Redis.new(host: host)
+  def self.new_redis(host = 'localhost', port = nil, password = nil)
+    Redis.new(host: host, port: port, password: password)
   end
 
   def self.new_logger(logfile)

--- a/vmpooler
+++ b/vmpooler
@@ -7,13 +7,15 @@ require 'lib/vmpooler'
 
 config = Vmpooler.config
 redis_host = config[:redis]['server']
+redis_port = config[:redis]['port']
+redis_password = config[:redis]['password']
 logger_file = config[:config]['logfile']
 
 metrics = Vmpooler.new_metrics(config)
 
 api = Thread.new do
   thr = Vmpooler::API.new
-  thr.helpers.configure(config, Vmpooler.new_redis(redis_host), metrics)
+  thr.helpers.configure(config, Vmpooler.new_redis(redis_host, redis_port, redis_password), metrics)
   thr.helpers.execute!
 end
 
@@ -21,7 +23,7 @@ manager = Thread.new do
   Vmpooler::PoolManager.new(
     config,
     Vmpooler.new_logger(logger_file),
-    Vmpooler.new_redis(redis_host),
+    Vmpooler.new_redis(redis_host, redis_port, redis_password),
     metrics
   ).execute!
 end


### PR DESCRIPTION
This commit adds options for setting redis port and password. Without this change it is not possible to specify the redis port or password.