### PR TITLE
Update to generic launcher

### DIFF
--- a/scripts/vmpooler.service
+++ b/scripts/vmpooler.service
@@ -6,7 +6,7 @@ After=basic.target network.target
 [Service]
 EnvironmentFile=-/etc/default/vmpooler
 WorkingDirectory=/opt/vmpooler
-ExecStart=/opt/jruby/bin/jruby /opt/vmpooler/vmpooler -s Puma -E production
+ExecStart=/opt/vmpooler/vmpooler -s Puma -E production
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=process
 


### PR DESCRIPTION
I realized the launcher itself handles looking up the Ruby interpreter with /usr/bin/env ruby. Manually specifying an interpreter is going to try to circumvent that and isn't nearly as portable as an example service. By moving this sample script back to the generic launcher directly a user can choose to handle how /usr/bin/env looks up Ruby, whether it's with a jruby installation, rbenv, or however the user wishes.