### PR TITLE
Update ruby versions for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,32 +6,34 @@ services:
 
 matrix:
   include:
-    - rvm: 2.3.3
+    - rvm: 2.3.7
       env: "CHECK=rubocop"
 
-    - rvm: 2.1.1
+    - rvm: 2.2.10
       env: "CHECK=test"
 
-    - rvm: 2.2.1
+    - rvm: 2.3.7
       env: "CHECK=test"
 
-    - rvm: 2.3.3
+    - rvm: 2.4.4
       env: "CHECK=test"
 
-    - rvm: jruby-9.1.13.0
+    - rvm: 2.5.1
+      env: "CHECK=test"
+
+    - rvm: jruby-9.1.17.0
       env: "CHECK=test"
 
   # Remove the allow_failures section once
   # Rubocop is required for Travis to pass a build
   allow_failures:
-    - rvm: 2.3.3
+    - rvm: 2.3.7
       env: "CHECK=rubocop"
-  
-# Pin to specific rubygem and bundler for jruby tests
+
 install:
-  - gem update --system 2.6.14
-  - gem install bundler --version 1.15.4
-  - bundle _1.15.4_ --version
-  - bundle _1.15.4_ install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
-script: 
-  - "bundle _1.15.4_ exec rake $CHECK"
+  - gem update --system
+  - gem install bundler
+  - bundle --version
+  - bundle install --jobs=3 --retry=3 --path=${BUNDLE_PATH:-vendor/bundle}
+script:
+  - "bundle exec rake $CHECK"


### PR DESCRIPTION
This commit updates ruby versions specified for use when testing in
travis.yml. Specifically, ruby 2.4.x and 2.5.x are added, while 2.2 is
updated to 2.2.10, and 2.3 is updated to 2.3.7. Additionally, jruby
testing is updated to use 9.1.17.0. Without this change we do not test
ruby 2.4.x or 2.5.x with vmpooler.