### PR TITLE
Change default vsphere connection behavior

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -410,7 +410,7 @@ module Vmpooler
             connection = RbVmomi::VIM.connect host: provider_config['server'],
                                               user: provider_config['username'],
                                               password: provider_config['password'],
-                                              insecure: provider_config['insecure'] || true
+                                              insecure: provider_config['insecure'] || false
             metrics.increment('connect.open')
             return connection
           rescue => err

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -52,7 +52,7 @@
 #
 #   - insecure
 #     Whether to ignore any HTTPS negotiation errors (e.g. untrusted self-signed certificates)
-#     (optional: default true)
+#     (optional: default false)
 #
 #   - datacenter
 #     The datacenter within vCenter to manage VMs.  This can be overridden in the pool configuration


### PR DESCRIPTION
This commit changes the vsphere connection behavior to set insecure false. Without this change insecure is always set to true when making a connection regardless of the setting provided with the provider configuration.