### PR TITLE
(POOLER-31) Expire redis vm key when clone fails

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -245,7 +245,9 @@ module Vmpooler
 
         $metrics.timing("clone.#{pool_name}", finish)
       rescue => _err
-        $redis.srem('vmpooler__pending__' + pool_name, new_vmname)
+        $redis.srem("vmpooler__pending__#{pool_name}", new_vmname)
+        expiration_ttl = $config[:redis]['data_ttl'].to_i * 60 * 60
+        $redis.expire("vmpooler__vm__#{new_vmname}", expiration_ttl)
         raise _err
       ensure
         $redis.decr('vmpooler__tasks__clone')

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -583,6 +583,7 @@ EOT
 
   describe '#_clone_vm' do
     let (:pool_object) { { 'name' => pool } }
+    let (:redis_ttl) { 1 }
 
     before do
       expect(subject).not_to be_nil
@@ -593,6 +594,8 @@ EOT
 ---
 :config:
   prefix: "prefix"
+:redis:
+  ttl: #{redis_ttl}
 EOT
       )
     }
@@ -662,6 +665,11 @@ EOT
         expect(redis.get('vmpooler__tasks__clone')).to eq('2')
         expect{subject._clone_vm(pool_object,provider)}.to raise_error(/MockError/)
         expect(redis.get('vmpooler__tasks__clone')).to eq('1')
+      end
+
+      it 'should expire the vm metadata' do
+        expect(redis).to receive(:expire)
+        expect{subject._clone_vm(pool_object,provider)}.to raise_error(/MockError/)
       end
 
       it 'should raise the error' do


### PR DESCRIPTION
This commit updates pool_manager to expire a redis VM key when a clone fails. Without this change VMs that fail to clone have their metadata left forever.