### PR TITLE
Reduce object lookups for finding folders

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -46,8 +46,7 @@ module Vmpooler
           vms = []
           @connection_pool.with_metrics do |pool_object|
             connection = ensured_vsphere_connection(pool_object)
-            foldername = pool_config(pool_name)['folder']
-            folder_object = find_folder(pool_name, connection)
+            folder_object = find_vm_folder(pool_name, connection)
 
             return vms if folder_object.nil?
 
@@ -232,7 +231,7 @@ module Vmpooler
             )
 
             begin
-              vm_target_folder = find_folder(pool_name, connection)
+              vm_target_folder = find_vm_folder(pool_name, connection)
               if vm_target_folder.nil? and @config[:config].key?('create_folders') and @config[:config]['create_folders'] == true
                 vm_target_folder = create_folder(connection, target_folder_path, target_datacenter_name)
               end
@@ -581,7 +580,7 @@ module Vmpooler
         # +pool_name+:: the pool to find the folder for
         # +connection+:: the vsphere connection object
         # returns a ManagedObjectReference for the folder found or nil if not found
-        def find_folder(pool_name, connection)
+        def find_vm_folder(pool_name, connection)
           # Find a folder by its inventory path and return the object
           # Returns nil when the object found is not a folder
           pool_configuration = pool_config(pool_name)

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -353,6 +353,8 @@ module Vmpooler
           nil
         end
 
+        # Return a hash of VM data
+        # Provides vmname, hostname, template, poolname, boottime and powerstate information
         def generate_vm_hash(vm_object, pool_name)
           pool_configuration = pool_config(pool_name)
           return nil if pool_configuration.nil?

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -97,7 +97,7 @@ EOT
 
     context 'Given a pool folder that is missing' do
       before(:each) do
-        expect(subject).to receive(:find_folder).with(poolname,connection).and_return(nil)
+        expect(subject).to receive(:find_vm_folder).with(poolname,connection).and_return(nil)
       end
 
       it 'should get a connection' do
@@ -115,7 +115,7 @@ EOT
 
     context 'Given an empty pool folder' do
       before(:each) do
-        expect(subject).to receive(:find_folder).with(poolname,connection).and_return(folder_object)
+        expect(subject).to receive(:find_vm_folder).with(poolname,connection).and_return(folder_object)
       end
 
       it 'should get a connection' do
@@ -144,7 +144,7 @@ EOT
           folder_object.childEntity << mock_vm
         end
 
-        expect(subject).to receive(:find_folder).with(poolname,connection).and_return(folder_object)
+        expect(subject).to receive(:find_vm_folder).with(poolname,connection).and_return(folder_object)
       end
 
       it 'should get a connection' do
@@ -344,7 +344,7 @@ EOT
         allow(subject).to receive(:find_template_vm).and_return(new_template_object)
         allow(template_vm).to receive(:CloneVM_Task).and_return(clone_vm_task)
         allow(clone_vm_task).to receive(:wait_for_completion).and_return(new_vm_object)
-        allow(subject).to receive(:find_folder).and_return(folder_object)
+        allow(subject).to receive(:find_vm_folder).and_return(folder_object)
       end
 
       it 'should return a hash' do
@@ -1467,14 +1467,14 @@ EOT
     end
   end
 
-  describe '#find_folder' do
+  describe '#find_vm_folder' do
     let(:foldername) { 'folder'}
 
     context 'with no folder hierarchy' do
 
       it 'should return nil if the folder is not found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(nil)
-        expect(subject.find_folder(poolname,connection)).to be_nil
+        expect(subject.find_vm_folder(poolname,connection)).to be_nil
       end
     end
 
@@ -1484,13 +1484,13 @@ EOT
       it 'should return the folder when found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(folder_object)
         allow(folder_object).to receive(:class).and_return(RbVmomi::VIM::Folder)
-        result = subject.find_folder(poolname,connection)
+        result = subject.find_vm_folder(poolname,connection)
         expect(result.name).to eq(foldername)
       end
 
       it 'should return nil if the folder is not found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(nil)
-        expect(subject.find_folder(poolname,connection)).to be_nil
+        expect(subject.find_vm_folder(poolname,connection)).to be_nil
       end
     end
 
@@ -1500,13 +1500,13 @@ EOT
       it 'should return the folder when found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(folder_object)
         allow(folder_object).to receive(:class).and_return(RbVmomi::VIM::Folder)
-        result = subject.find_folder(poolname,connection)
+        result = subject.find_vm_folder(poolname,connection)
         expect(result.name).to eq(foldername)
       end
 
       it 'should return nil if the folder is not found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(nil)
-        expect(subject.find_folder(poolname,connection)).to be_nil
+        expect(subject.find_vm_folder(poolname,connection)).to be_nil
       end
     end
 
@@ -1514,7 +1514,7 @@ EOT
 
       it 'should not return a VM' do
         pending('https://github.com/puppetlabs/vmpooler/issues/204')
-        result = subject.find_folder(foldername,connection,datacenter_name)
+        result = subject.find_vm_folder(foldername,connection,datacenter_name)
         expect(result).to_not be_nil
         expect(result.name).to eq(foldername)
         expect(result.is_a? RbVmomi::VIM::VirtualMachine).to be false
@@ -1528,13 +1528,13 @@ EOT
       it 'should return the folder when found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(folder_object)
         allow(folder_object).to receive(:class).and_return(RbVmomi::VIM::Folder)
-        result = subject.find_folder(poolname,connection)
+        result = subject.find_vm_folder(poolname,connection)
         expect(result.name).to eq(foldername)
       end
 
       it 'should return nil if the folder is not found' do
         allow(connection.searchIndex).to receive(:FindByInventoryPath).and_return(nil)
-        expect(subject.find_folder(poolname,connection)).to be_nil
+        expect(subject.find_vm_folder(poolname,connection)).to be_nil
       end
     end
   end

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -190,7 +190,7 @@ EOT
         expect(result['name']).to eq(vmname)
       end
 
-      ['hostname','template','poolname','boottime','powerstate'].each do |testcase|
+      ['hostname','boottime','powerstate'].each do |testcase|
         it "should return nil for #{testcase}" do
           result = subject.get_vm(poolname,vmname)
 


### PR DESCRIPTION
These commits reduce the number of objects looked up when finding VM folders. Additionally, object lookup methods that scan for a folder with a matching name are removed in favor of searchIndex with FindByInventoryPath. Without this change the time it takes to find VM folders is much longer and more resource intensive.