### PR TITLE
Ensure template deltas are created once

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -628,6 +628,11 @@ module Vmpooler
           prepare_template(pool, provider)
           prepared_template = $redis.hget('vmpooler__template__prepared', pool['name'])
         end
+      elsif not prepared_template == pool['template']
+        mutex.synchronize do
+          prepare_template(pool, provider)
+          prepared_template = $redis.hget('vmpooler__template__prepared', pool['name'])
+        end
       end
       return if configured_template.nil?
       return if configured_template == prepared_template
@@ -896,8 +901,6 @@ module Vmpooler
       $redis.set('vmpooler__tasks__clone', 0)
       # Clear out vmpooler__migrations since stale entries may be left after a restart
       $redis.del('vmpooler__migration')
-      # Ensure template deltas are created on each startup
-      $redis.del('vmpooler__template__prepared')
 
       # Copy vSphere settings to correct location.  This happens with older configuration files
       if !$config[:vsphere].nil? && ($config[:providers].nil? || $config[:providers][:vsphere].nil?)

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -628,10 +628,12 @@ module Vmpooler
           prepare_template(pool, provider)
           prepared_template = $redis.hget('vmpooler__template__prepared', pool['name'])
         end
-      elsif not prepared_template == pool['template']
-        mutex.synchronize do
-          prepare_template(pool, provider)
-          prepared_template = $redis.hget('vmpooler__template__prepared', pool['name'])
+      elsif prepared_template != pool['template']
+        if configured_template.nil?
+          mutex.synchronize do
+            prepare_template(pool, provider)
+            prepared_template = $redis.hget('vmpooler__template__prepared', pool['name'])
+          end
         end
       end
       return if configured_template.nil?

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1830,11 +1830,29 @@ EOT
     end
 
     context 'when prepared template is nil' do
-      before(:each) do
+
+      it 'should prepare the template' do
         expect(redis).to receive(:hget).with('vmpooler__template__prepared', pool).and_return(nil)
+        expect(subject).to receive(:prepare_template).with(config[:pools][0], provider)
+
+        subject.evaluate_template(config[:pools][0], provider)
+      end
+
+      it 'should not prepare the template again' do
+        expect(redis).to receive(:hget).with('vmpooler__template__prepared', pool).and_return(current_template)
+        expect(subject).to_not receive(:prepare_template).with(config[:pools][0], provider)
+
+        subject.evaluate_template(config[:pools][0], provider)
+      end
+    end
+
+    context 'when the configured pool template does not match the prepared template' do
+      before(:each) do
+        config[:pools][0]['template'] = new_template
       end
 
       it 'should prepare the template' do
+        expect(redis).to receive(:hget).with('vmpooler__template__prepared', pool).and_return(current_template)
         expect(subject).to receive(:prepare_template).with(config[:pools][0], provider)
 
         subject.evaluate_template(config[:pools][0], provider)
@@ -2291,7 +2309,6 @@ EOT
       it 'should run startup tasks only once' do
         expect(redis).to receive(:set).with('vmpooler__tasks__clone', 0).once
         expect(redis).to receive(:del).with('vmpooler__migration').once
-        expect(redis).to receive(:del).with('vmpooler__template__prepared').once
 
         subject.execute!(maxloop,0)
       end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1849,13 +1849,22 @@ EOT
     context 'when the configured pool template does not match the prepared template' do
       before(:each) do
         config[:pools][0]['template'] = new_template
+        expect(redis).to receive(:hget).with('vmpooler__template__prepared', pool).and_return(current_template)
       end
 
       it 'should prepare the template' do
-        expect(redis).to receive(:hget).with('vmpooler__template__prepared', pool).and_return(current_template)
         expect(subject).to receive(:prepare_template).with(config[:pools][0], provider)
 
         subject.evaluate_template(config[:pools][0], provider)
+      end
+
+      context 'if configured_template is provided' do
+        it 'should not run prepare_template' do
+          expect(redis).to receive(:hget).with('vmpooler__config__template', pool).and_return(current_template)
+          expect(subject).to_not receive(:prepare_template)
+
+          subject.evaluate_template(config[:pools][0], provider)
+        end
       end
     end
 


### PR DESCRIPTION
This commit updates how template delta disk creation is evaluated. Without this change template deltas are created for every template on each applicatoin startup. This change updates this behavior to instead run template delta disk creation only once per template configured for a pool. Without this change it is possible to get a template to a state where the XML depth is too great to be read with default settings and the template requires a new clone to resolve.