### PR TITLE
(POOLER-81) Add time_remaining information

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -644,7 +644,10 @@ module Vmpooler
           result[params[:hostname]]['running'] = ((Time.parse(rdata['destroy']) - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
           result[params[:hostname]]['state'] = 'destroyed'
         elsif rdata['checkout']
-          result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
+          running = Time.now - Time.parse(rdata['checkout'])
+          result[params[:hostname]]['running'] = format("%02dh %02dm %02ds", running / (60 * 60), (running / 60) % 60, running % 60)
+          remaining = Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60 - Time.now
+          result[params[:hostname]]['time_remaining'] = format("%02dh %02dm %02ds", remaining / (60 * 60), (remaining / 60) % 60, remaining % 60)
           result[params[:hostname]]['state'] = 'running'
         elsif rdata['check']
           result[params[:hostname]]['state'] = 'ready'

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -39,6 +39,26 @@ describe Vmpooler::API::V1 do
       create_token('abcdefghijklmnopqrstuvwxyz012345', 'jdoe', current_time)
     end
 
+    describe 'GET /vm/:hostname' do
+      it 'returns correct information on a running vm' do
+        create_running_vm 'pool1', 'abcdefghijklmnop'
+        get "#{prefix}/vm/abcdefghijklmnop"
+        expect_json(ok = true, http = 200)
+        expected = {
+          ok: true,
+          abcdefghijklmnop: {
+              template: "pool1",
+              lifetime: 0,
+              running: "00h 00m ..s",
+              time_remaining: "00h ..m ..s",
+              state: "running",
+              ip: ""
+          }
+        }
+        expect(last_response.body).to match(JSON.pretty_generate(expected))
+      end
+    end
+
     describe 'POST /vm' do
       it 'returns a single VM' do
         create_ready_vm 'pool1', 'abcdefghijklmnop'


### PR DESCRIPTION
Before, the only time calculation displayed for a given VM was the
lifetime parameter. Added the time_remaining parameter which will
display time until the VM is destroyed in hours, minutes, seconds.

Additionally, updated the running parameter to display in a similar
fashion as time_remaining.