### PR TITLE
(POOLER-34) Ship clone request to ready time to metrics

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -102,7 +102,7 @@ module Vmpooler
 
         # last boot time is displayed in API, and used by alarming script
         $redis.hset('vmpooler__lastboot', pool, Time.now)
-
+        $metrics.timing("time_to_ready_state.#{pool}", finish)
         $logger.log('s', "[>] [#{pool}] '#{vm}' moved from 'pending' to 'ready' queue")
       end
     end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -217,6 +217,14 @@ EOT
         subject.move_pending_vm_to_ready(vm, pool, host)
       end
 
+      it 'should receive time_to_ready_state metric' do
+        redis.hset("vmpooler__vm__#{vm}", 'clone',Time.now.to_s)
+        expect(metrics).to receive(:timing).with(/time_to_ready_state\./,/0/)
+
+        subject.move_pending_vm_to_ready(vm, pool, host)
+      end
+
+
       it 'should set the boot time in redis' do
         redis.hset("vmpooler__vm__#{vm}", 'clone',Time.now.to_s)
         expect(redis.hget('vmpooler__boot__' + Date.today.to_s, pool + ':' + vm)).to be_nil


### PR DESCRIPTION
Before, we were already capturing this metric but we failed to ship
it anywhere. This ships the appropriate metric as `time_to_ready_state`
Dashboards can be created easily in grafana.