### PR TITLE
(POOLER-81) Add time remaining information

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -646,8 +646,8 @@ module Vmpooler
         elsif rdata['checkout']
           result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
           result[params[:hostname]]['remaining'] = ((Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60 - Time.now) / 60 / 60).round(2)
-          result[params[:hostname]]['start_time'] = Time.parse(rdata['checkout'])
-          result[params[:hostname]]['end_time'] = Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60
+          result[params[:hostname]]['start_time'] = Time.parse(rdata['checkout']).to_datetime.rfc3339
+          result[params[:hostname]]['end_time'] = (Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60).to_datetime.rfc3339
           result[params[:hostname]]['state'] = 'running'
         elsif rdata['check']
           result[params[:hostname]]['state'] = 'ready'

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -645,6 +645,9 @@ module Vmpooler
           result[params[:hostname]]['state'] = 'destroyed'
         elsif rdata['checkout']
           result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
+          result[params[:hostname]]['remaining'] = ((Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60 - Time.now) / 60 / 60).round(2).abs
+          result[params[:hostname]]['start_time'] = Time.parse(rdata['checkout'])
+          result[params[:hostname]]['end_time'] = Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60
           result[params[:hostname]]['state'] = 'running'
         elsif rdata['check']
           result[params[:hostname]]['state'] = 'ready'

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -645,7 +645,7 @@ module Vmpooler
           result[params[:hostname]]['state'] = 'destroyed'
         elsif rdata['checkout']
           result[params[:hostname]]['running'] = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
-          result[params[:hostname]]['remaining'] = ((Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60 - Time.now) / 60 / 60).round(2).abs
+          result[params[:hostname]]['remaining'] = ((Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60 - Time.now) / 60 / 60).round(2)
           result[params[:hostname]]['start_time'] = Time.parse(rdata['checkout'])
           result[params[:hostname]]['end_time'] = Time.parse(rdata['checkout']) + rdata['lifetime'].to_i*60*60
           result[params[:hostname]]['state'] = 'running'

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -39,6 +39,28 @@ describe Vmpooler::API::V1 do
       create_token('abcdefghijklmnopqrstuvwxyz012345', 'jdoe', current_time)
     end
 
+    describe 'GET /vm/:hostname' do
+      it 'returns correct information on a running vm' do
+        create_running_vm 'pool1', 'abcdefghijklmnop'
+        get "#{prefix}/vm/abcdefghijklmnop"
+        expect_json(ok = true, http = 200)
+        expected = {
+          ok: true,
+          abcdefghijklmnop: {
+              template: "pool1",
+              lifetime: 0,
+              running: 0.0,
+              remaining: 0.0,
+              start_time: "#{current_time}",
+              end_time: "#{current_time}",
+              state: "running",
+              ip: ""
+          }
+        }
+        expect(last_response.body).to match(JSON.pretty_generate(expected))
+      end
+    end
+
     describe 'POST /vm' do
       it 'returns a single VM' do
         create_ready_vm 'pool1', 'abcdefghijklmnop'

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -50,8 +50,8 @@ describe Vmpooler::API::V1 do
         expect(response_body["lifetime"]).to eq(0)
         expect(response_body["running"]).to be >= 0
         expect(response_body["remaining"]).to be <= 0
-        expect(response_body["start_time"]).to eq("#{current_time}")
-        expect(response_body["end_time"]).to eq("#{current_time}")
+        expect(response_body["start_time"]).to eq(current_time.to_datetime.rfc3339)
+        expect(response_body["end_time"]).to eq(current_time.to_datetime.rfc3339)
         expect(response_body["state"]).to eq("running")
         expect(response_body["ip"]).to eq("")
       end

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -44,20 +44,16 @@ describe Vmpooler::API::V1 do
         create_running_vm 'pool1', 'abcdefghijklmnop'
         get "#{prefix}/vm/abcdefghijklmnop"
         expect_json(ok = true, http = 200)
-        expected = {
-          ok: true,
-          abcdefghijklmnop: {
-              template: "pool1",
-              lifetime: 0,
-              running: 0.0,
-              remaining: 0.0,
-              start_time: "#{current_time}",
-              end_time: "#{current_time}",
-              state: "running",
-              ip: ""
-          }
-        }
-        expect(last_response.body).to match(JSON.pretty_generate(expected))
+        response_body = (JSON.parse(last_response.body)["abcdefghijklmnop"])
+
+        expect(response_body["template"]).to eq("pool1")
+        expect(response_body["lifetime"]).to eq(0)
+        expect(response_body["running"]).to be >= 0
+        expect(response_body["remaining"]).to be <= 0
+        expect(response_body["start_time"]).to eq("#{current_time}")
+        expect(response_body["end_time"]).to eq("#{current_time}")
+        expect(response_body["state"]).to eq("running")
+        expect(response_body["ip"]).to eq("")
       end
     end
 


### PR DESCRIPTION
Before, the only time calculation displayed for a given VM was the
lifetime parameter. Added the remaining parameter which will
display time until the VM is destroyed as a float.

Additionally, start_time and end_time were added to api to return
as RFC3339 based times (e.g. 2018-07-11T09:54:51-07:00).

/cc @glennsarti @johnmccabe @mattkirby 