### PR TITLE
(maint) Remove ruby 2.2.10 from travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ matrix:
     - rvm: 2.3.7
       env: "CHECK=rubocop"
 
-    - rvm: 2.2.10
-      env: "CHECK=test"
-
     - rvm: 2.3.7
       env: "CHECK=test"
 


### PR DESCRIPTION
This commit removes ruby 2.2.10 from travis configuration. Without this change travis tests fail since vmpooler has dropped ruby 2.2.10 support.