### PR TITLE
Update entrypoint in dockerfile for vmpooler gem

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,3 +19,5 @@ RUN gem install vmpooler && \
       chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
+
+CMD ["vmpooler"]

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-set -- /var/lib/vmpooler/vmpooler "$@"
+set -- vmpooler "$@"
 
 exec "$@"


### PR DESCRIPTION
This commit updates dockerfile entrypoint to remove the explicit
vmpooler executable path. Additionally, CMD is added to run a default
command when runtime parameters are not passed in by the user. Without
this change the vmpooler executable path is hardcoded into a directory
that will not exist.