### PR TITLE
(POOLER-128) Remove references to VM mutex when destroying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.1.0...master)
 
+### Fixed
+
+- (POOLER-128) VM specific mutex objects are not dereferenced when a VM is destroyed
+
 # [0.1.0](https://github.com/puppetlabs/vmpooler/compare/4c858d012a262093383e57ea6db790521886d8d4...master)
 
 ### Fixed

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -313,6 +313,7 @@ module Vmpooler
         $logger.log('s', "[-] [#{pool}] '#{vm}' destroyed in #{finish} seconds")
         $metrics.timing("destroy.#{pool}", finish)
       end
+      dereference_mutex(vm)
     end
 
     def purge_unused_vms_and_folders
@@ -679,6 +680,14 @@ module Vmpooler
 
     def vm_mutex(vmname)
       @vm_mutex[vmname] || @vm_mutex[vmname] = Mutex.new
+    end
+
+    def dereference_mutex(vmname)
+      if @vm_mutex.delete(vmname)
+        return true
+      else
+        return
+      end
     end
 
     def sync_pool_template(pool)

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -726,6 +726,12 @@ EOT
 
         subject._destroy_vm(vm,pool,provider)
       end
+
+      it 'should dereference the mutex' do
+        expect(subject).to receive(:dereference_mutex)
+
+        subject._destroy_vm(vm,pool,provider)
+      end
     end
 
     context 'when the VM destruction raises an eror' do
@@ -1687,6 +1693,26 @@ EOT
       first = subject.vm_mutex(vm)
       second = subject.vm_mutex(vm)
       expect(first).to be(second)
+    end
+  end
+
+  describe '#dereference_mutex' do
+    it 'should return nil when no mutex is dereferenced' do
+      expect(subject.dereference_mutex(vm)).to be_nil
+    end
+
+    it 'should return true when a mutex is dereferenced' do
+      subject.vm_mutex(vm)
+      expect(subject.dereference_mutex(vm)).to be true
+    end
+
+    it 'should dereference the mutex' do
+      mutex = subject.vm_mutex(vm)
+
+      subject.dereference_mutex(vm)
+
+      result = subject.vm_mutex(vm)
+      expect(result).to_not eq(mutex)
     end
   end
 


### PR DESCRIPTION
This commit updates destroy_vm to remove references to its mutex tracking object when destroyed. Without this change a VM that is destroyed will leave its mutex tracking object forever causing the pool manager memory footprint to increase.