### PR TITLE
Remove VM from completed only after destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ git logs & PR history.
 ### Fixed
 
 - (POOLER-128) VM specific mutex objects are not dereferenced when a VM is destroyed
+- A VM that is being destroyed is reported as discovered
 
 # [0.1.0](https://github.com/puppetlabs/vmpooler/compare/4c858d012a262093383e57ea6db790521886d8d4...master)
 

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -298,7 +298,6 @@ module Vmpooler
       mutex = vm_mutex(vm)
       return if mutex.locked?
       mutex.synchronize do
-        $redis.srem('vmpooler__completed__' + pool, vm)
         $redis.hdel('vmpooler__active__' + pool, vm)
         $redis.hset('vmpooler__vm__' + vm, 'destroy', Time.now)
 
@@ -308,6 +307,8 @@ module Vmpooler
         start = Time.now
 
         provider.destroy_vm(pool, vm)
+
+        $redis.srem('vmpooler__completed__' + pool, vm)
 
         finish = format('%.2f', Time.now - start)
         $logger.log('s', "[-] [#{pool}] '#{vm}' destroyed in #{finish} seconds")


### PR DESCRIPTION
This commit updates destroy_vm to remove the redis member from the completed queue only after a destroy has been completed. Without this change a VM that is being destroyed will be logged as discovered when inventory is checked since it has already been removed from the completed queue.