### PR TITLE
(POOLER-114) Refactor check_pool in pool_manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.2.0...master)
 
+### Added
+- Re-write check\_pool in pool\_manager to improve readability
+- Add a docker-compose file for testing vmpooler
+
 # [0.2.0](https://github.com/puppetlabs/vmpooler/compare/0.1.0...0.2.0)
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ To run only the manager component
 docker run -it vmpooler manager
 ```
 
+### docker-compose
+
+A docker-compose file is provided to support running vmpooler easily via docker-compose.
+
+```
+docker-compose -f docker/docker-compose.yml up
+```
+
 ### Running Docker inside Vagrant
 
 A vagrantfile is included in this repository. Please see [vagrant instructions](docs/vagrant.md) for details.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@
 
 FROM jruby:9.1-jdk
 
-COPY ./docker/docker-entrypoint.sh /usr/local/bin/
+COPY docker/docker-entrypoint.sh /usr/local/bin/
 
 ENV LOGFILE=/dev/stdout \
       RACK_ENV=production
@@ -19,5 +19,3 @@ RUN gem install vmpooler && \
       chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]
-
-CMD ["vmpooler"]

--- a/vmpooler.yaml.dummy-example
+++ b/vmpooler.yaml.dummy-example
@@ -14,7 +14,7 @@
 
 :config:
   site_name: 'vmpooler'
-  logfile: '/var/log/vmpooler/vmpooler.log'
+  logfile: '/var/log/vmpooler.log'
   task_limit: 10
   timeout: 15
   vm_checktime: 15

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -371,7 +371,7 @@
 #     (optional; default: '10')
 #
 #   - timeout
-#     How long (in minutes) before marking a clone as 'failed' and retrying.
+#     How long (in minutes) before marking a clone in 'pending' queues as 'failed' and retrying.
 #     (optional; default: '15')
 #
 #   - vm_checktime
@@ -529,7 +529,7 @@
 #     (optional)
 #
 #   - timeout
-#     How long (in minutes) before marking a clone as 'failed' and retrying.
+#     How long (in minutes) before marking a clone in 'pending' queues as 'failed' and retrying.
 #     This setting overrides any globally-configured timeout setting.
 #     (optional; default: '15')
 #


### PR DESCRIPTION
This commit refactorss the check_pool method in pool_manager.
Specifically, each commented section describing a stage of check_pool is
broken out into a separate method and check_pool is simplified by
calling these methods. Without this change it is difficult to follow the
intent for or make changes to check_pool.

Additionally, a docker-compose file is added to make it simple to launch
an all-in-one vmpooler instance along with a separate redis server with
docker.