### PR TITLE
(POOLER-130) Improve delta disk creation handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.2.0...master)
+- Better handle delta disk creation errors (POOLER-130)
 
 # [0.2.0](https://github.com/puppetlabs/vmpooler/compare/0.1.0...0.2.0)
 

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -723,7 +723,16 @@ module Vmpooler
     end
 
     def prepare_template(pool, provider)
-      provider.create_template_delta_disks(pool) if $config[:config]['create_template_delta_disks']
+      if $config[:config]['create_template_delta_disks']
+        unless $redis.sismember('vmpooler__template__deltas', pool['template'])
+          begin
+            provider.create_template_delta_disks(pool)
+            $redis.sadd('vmpooler__template__deltas', pool['template'])
+          rescue => err
+            $logger.log('s', "[!] [#{pool['name']}] failed while preparing a template with an error. As a result vmpooler could not create the template delta disks. Either a template delta disk already exists, or the template delta disk creation failed. The error is: #{err}")
+          end
+        end
+      end
       $redis.hset('vmpooler__template__prepared', pool['name'], pool['template'])
     end
 

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1942,6 +1942,19 @@ EOT
         subject.prepare_template(config[:pools][0], provider)
       end
     end
+
+    context 'when template delta disk creation fails' do
+      before(:each) do
+        allow(redis).to receive(:hset)
+        expect(provider).to receive(:create_template_delta_disks).and_raise("MockError")
+      end
+
+      it 'should log a message when delta disk creation returns an error' do
+        expect(logger).to receive(:log).with('s', "[!] [#{pool}] failed while preparing a template with an error. As a result vmpooler could not create the template delta disks. Either a template delta disk already exists, or the template delta disk creation failed. The error is: MockError")
+
+        subject.prepare_template(config[:pools][0], provider)
+      end
+    end
   end
 
   describe 'evaluate_template' do


### PR DESCRIPTION
This commit updates delta disk creation to reduce the likelihood of this being run more than once for any given template. Without this change an error can be generated with vsphere 6.5 or later when a template is updated, and then the update is reverted. The error prevents the image from being used because the template is never marked as prepared. To address this any failure is now logged, and the template is marked as prepared regardless of whether this was successful, or not, which allows the image to be used despite the error. This failure mode is more graceful and allows the pool to continue to function.