### PR TITLE
(POOLER-129) Allow setting weights for backends

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
 gem 'json', '>= 1.8'
+gem 'pickup', '~> 0.0.11'
 gem 'puma', '~> 3.11'
 gem 'rack', '~> 2.0'
 gem 'rake', '~> 12.3'

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -1,15 +1,16 @@
 module Vmpooler
   require 'date'
   require 'json'
-  require 'open-uri'
   require 'net/ldap'
+  require 'open-uri'
+  require 'pickup'
   require 'rbvmomi'
   require 'redis'
+  require 'set'
   require 'sinatra/base'
   require 'time'
   require 'timeout'
   require 'yaml'
-  require 'set'
 
   %w[api graphite logger pool_manager statsd dummy_statsd generic_connection_pool].each do |lib|
     require "vmpooler/#{lib}"

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -36,16 +36,46 @@ module Vmpooler
       validate_token(backend)
     end
 
-    def fetch_single_vm(template)
-      vm = backend.spop('vmpooler__ready__' + template)
-      return [vm, template] if vm
+    def pool_backend(pool)
+      pool_index = pool_index(pools)
+      pool_config = pools[pool_index[pool]]
+      backend = pool_config['clone_target'] || config['clone_target'] || 'default'
+      return backend
+    end
 
+    def fetch_single_vm(template)
+      template_backends = [template]
       aliases = Vmpooler::API.settings.config[:alias]
-      if aliases && aliased_template = aliases[template]
-        vm = backend.spop('vmpooler__ready__' + aliased_template)
-        return [vm, aliased_template] if vm
+      if aliases
+        template_backends << aliases[template] if aliases[template]
+
+        pool_index = pool_index(pools)
+        weighted_pools = {}
+        template_backends.each do |t|
+          next unless pool_index.key? t
+          index = pool_index[t]
+          clone_target = pools[index]['clone_target'] || config['clone_target']
+          next unless config.key?('backend_weight')
+          weight = config['backend_weight'][clone_target]
+          if weight
+            weighted_pools[t] = weight
+          end
+        end
+
+        if weighted_pools.count == template_backends.count
+          pickup = Pickup.new(weighted_pools)
+          selection = pickup.pick
+          template_backends.delete(selection)
+          template_backends.unshift(selection)
+        else
+          template_backends = template_backends.sample(template_backends.count)
+        end
       end
 
+      template_backends.each do |t|
+        vm = backend.spop('vmpooler__ready__' + t)
+        return [vm, t] if vm
+      end
       [nil, nil]
     end
 

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -428,7 +428,7 @@ module Vmpooler
 
         def vm_ready?(_pool_name, vm_name)
           begin
-            open_socket(vm_name)
+            open_socket(vm_name, global_config[:config]['domain'])
           rescue => _err
             return false
           end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -2974,9 +2974,7 @@ EOT
         # mock response from create_inventory
         {vm => 1}
       }
-      let(:big_lifetime) {
-        2000
-      }
+      let(:big_lifetime) { 2000 }
       before(:each) do
         allow(subject).to receive(:check_ready_vm)
         create_ready_vm(pool,vm,token)
@@ -2992,7 +2990,7 @@ EOT
         expect(subject).to receive(:check_ready_vm).and_raise(RuntimeError,'MockError')
         expect(logger).to receive(:log).with('d', "[!] [#{pool}] _check_pool failed with an error while evaluating ready VMs: MockError")
 
-        subject.check_ready_pool_vms(pool, provider, pool_check_response, inventory)
+        subject.check_ready_pool_vms(pool, provider, pool_check_response, inventory, big_lifetime)
       end
 
       it 'should use the pool TTL if set' do
@@ -3511,12 +3509,8 @@ EOT
       end
 
       it 'captures #create_inventory errors correctly' do
-        allow(subject).to receive(:create_inventory).and_raise(
-          RuntimeError,'Mock Error'
-        )
-        expect {
-          subject._check_pool(pool_object, provider)
-        }.to_not raise_error(RuntimeError, /Mock Error/)
+        allow(subject).to receive(:create_inventory).and_raise(RuntimeError,'Mock Error')
+        subject._check_pool(pool_object, provider)
       end
 
       it 'should return early if an error occurs' do

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -925,9 +925,10 @@ EOT
   end
 
   describe '#vm_ready?' do
+    let(:domain) { nil }
     context 'When a VM is ready' do
       before(:each) do
-        expect(subject).to receive(:open_socket).with(vmname)
+        expect(subject).to receive(:open_socket).with(vmname, domain)
       end
 
       it 'should return true' do
@@ -939,7 +940,7 @@ EOT
       # TODO not sure how to handle a VM that is passed in but
       # not located in the pool.  Is that ready or not?
       before(:each) do
-        expect(subject).to receive(:open_socket).with(vmname)
+        expect(subject).to receive(:open_socket).with(vmname, domain)
       end
 
       it 'should return true' do

--- a/vmpooler.gemspec
+++ b/vmpooler.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.bindir        = 'bin'
   s.executables   = 'vmpooler'
   s.require_paths = ["lib"]
+  s.add_dependency 'pickup', '~> 0.0.11'
   s.add_dependency 'puma', '~> 3.11'
   s.add_dependency 'rack', '~> 2.0'
   s.add_dependency 'rake', '~> 12.3'


### PR DESCRIPTION
This commit updates get_vm in the vmpooler API to allow for setting weights for backends. Additionally, when an alias for a pool exists, and the backend configured is not weighted, then the selection of the pool based on alias will be randomly sampled. Without this change any pool with the title of the alias is exhausted before an alternate pool with the configured alias is used, which results in an uneven distribution of VMs. When all backends involved are configured with weighted values the VM selection will be based on probability using those weights.

A bug is fixed when setting the default ttl for check_ready_vm.

Pickup is added to handle weighted VM selection.

A dockerfile is added that allows for building and installing vmpooler
from the current HEAD in docker to make for easy testing.
