### PR TITLE
(POOLER-131) Return requested name when getting VMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ git logs & PR history.
 
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.2.1...master)
 
+### Fixed
+- Return label used to request VMs when fulfilling VM requests (POOLER-131)
+
 # [0.2.1](https://github.com/puppetlabs/vmpooler/compare/0.2.0...0.2.1)
 
 ### Fixed

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -82,7 +82,7 @@ describe Vmpooler::API::V1 do
 
         expected = {
           ok: true,
-          pool1: {
+          poolone: {
             hostname: 'abcdefghijklmnop'
           }
         }

--- a/spec/integration/api/v1/vm_template_spec.rb
+++ b/spec/integration/api/v1/vm_template_spec.rb
@@ -63,7 +63,7 @@ describe Vmpooler::API::V1 do
 
         expected = {
           ok: true,
-          pool1: {
+          poolone: {
             hostname: 'abcdefghijklmnop'
           }
         }


### PR DESCRIPTION
This commit updates fetch_single_vm to return the name of the template that was requested, instead of the name of the pool providing the VM to meet the request. Without this change, when an alias is used for fetching a VM, a different pool title may be returned containing the requested VMs than the user initially requested.