### PR TITLE
(POOLER-132) Sync pool size on dashboard start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.2.2...master)
 
+### Fixed
+- Sync pool size before dashboard is displayed (POOLER-132)
+
 # [0.2.2](https://github.com/puppetlabs/vmpooler/compare/0.2.1...0.2.2)
 
 ### Fixed

--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -14,10 +14,6 @@ module Vmpooler
       JSON.pretty_generate(result)
     end
 
-    get '/' do
-      redirect to('/dashboard/')
-    end
-
     # Load dashboard components
     begin
       require 'dashboard'

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -211,6 +211,11 @@ module Vmpooler
       end
     end
 
+    get '/' do
+      sync_pool_sizes
+      redirect to('/dashboard/')
+    end
+
     # Provide run-time statistics
     #
     # Example:


### PR DESCRIPTION
This commit updates the dashboard for vmpooler to ensure it is synchronized with any redis based configuration values before displaying the dashboard. Without this change the pool size value may be displayed incorrectly if the value has been set via the /config/poolsize API endpoint.