### PR TITLE
(POOLER-133) Identify when a ready VM has failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ git logs & PR history.
 
 ### Fixed
 - Sync pool size before dashboard is displayed (POOLER-132)
+- Remove a failed VM from the ready queue (POOLER-133)
+- Begin checking ready VMs to ensure alive after 1 minute by default
 
 # [0.2.2](https://github.com/puppetlabs/vmpooler/compare/0.2.1...0.2.2)
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,11 +16,11 @@ services:
     environment:
       - VMPOOLER_DEBUG=true # for use of dummy auth
       - VMPOOLER_CONFIG_FILE=/etc/vmpooler/vmpooler.yaml
-      - REDIS_SERVER=redis
+      - REDIS_SERVER=redislocal
     image: vmpooler-local
     depends_on:
-      - redis
-  redis:
+      - redislocal
+  redislocal:
     image: redis
     ports:
       - "6379:6379"

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -100,7 +100,6 @@ Example minimal configuration file:
   logfile: '/var/log/vmpooler.log'
   task_limit: 10
   timeout: 15
-  vm_checktime: 15
   vm_lifetime: 12
   vm_lifetime_auth: 24
   allowed_tags:

--- a/examples/vmpooler.yaml.dummy-example.aliasedpools
+++ b/examples/vmpooler.yaml.dummy-example.aliasedpools
@@ -17,7 +17,7 @@
   logfile: '/Users/samuel/workspace/vmpooler/vmpooler.log'
   task_limit: 10
   timeout: 15
-  vm_checktime: 15
+  vm_checktime: 1
   vm_lifetime: 12
   vm_lifetime_auth: 24
   allowed_tags:

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -49,7 +49,7 @@ module Vmpooler
     # Set some configuration defaults
     parsed_config[:config]['task_limit'] = ENV['TASK_LIMIT'] || parsed_config[:config]['task_limit'] || 10
     parsed_config[:config]['migration_limit'] = ENV['MIGRATION_LIMIT'] if ENV['MIGRATION_LIMIT']
-    parsed_config[:config]['vm_checktime'] = ENV['VM_CHECKTIME'] || parsed_config[:config]['vm_checktime'] || 15
+    parsed_config[:config]['vm_checktime'] = ENV['VM_CHECKTIME'] || parsed_config[:config]['vm_checktime'] || 1
     parsed_config[:config]['vm_lifetime'] = ENV['VM_LIFETIME'] || parsed_config[:config]['vm_lifetime']  || 24
     parsed_config[:config]['prefix'] = ENV['VM_PREFIX'] || parsed_config[:config]['prefix'] || ''
 
@@ -99,6 +99,9 @@ module Vmpooler
       redis = new_redis(parsed_config[:redis]['server'], parsed_config[:redis]['port'], parsed_config[:redis]['password'])
       parsed_config[:pools] = load_pools_from_redis(redis)
     end
+
+    # Create an index of pools by title
+    parsed_config[:pool_index] = pool_index(parsed_config[:pools])
 
     parsed_config[:pools].each do |pool|
       parsed_config[:pool_names] << pool['name']
@@ -160,5 +163,15 @@ module Vmpooler
 
   def self.pools(conf)
     conf[:pools]
+  end
+
+  def self.pool_index(pools)
+    pools_hash = {}
+    index = 0
+    for pool in pools
+      pools_hash[pool['name']] = index
+      index += 1
+    end
+    pools_hash
   end
 end

--- a/spec/fixtures/vmpooler.yaml
+++ b/spec/fixtures/vmpooler.yaml
@@ -17,7 +17,7 @@
   logfile: '/var/log/vmpooler.log'
   task_limit: 10
   timeout: 15
-  vm_checktime: 15
+  vm_checktime: 1
   vm_lifetime: 12
   vm_lifetime_auth: 24
   allowed_tags:

--- a/spec/fixtures/vmpooler2.yaml
+++ b/spec/fixtures/vmpooler2.yaml
@@ -17,7 +17,7 @@
   logfile: '/var/log/vmpooler.log'
   task_limit: 10
   timeout: 15
-  vm_checktime: 15
+  vm_checktime: 1
   vm_lifetime: 12
   vm_lifetime_auth: 24
   allowed_tags:

--- a/vmpooler.yaml.dummy-example
+++ b/vmpooler.yaml.dummy-example
@@ -17,7 +17,7 @@
   logfile: '/var/log/vmpooler.log'
   task_limit: 10
   timeout: 15
-  vm_checktime: 15
+  vm_checktime: 1
   vm_lifetime: 12
   vm_lifetime_auth: 24
   allowed_tags:

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -376,7 +376,7 @@
 #
 #   - vm_checktime
 #     How often (in minutes) to check the sanity of VMs in 'ready' queues.
-#     (optional; default: '15')
+#     (optional; default: '1')
 #
 #   - vm_lifetime
 #     How long (in hours) to keep VMs in 'running' queues before destroying.
@@ -492,7 +492,7 @@
   logfile: '/var/log/vmpooler.log'
   task_limit: 10
   timeout: 15
-  vm_checktime: 15
+  vm_checktime: 1
   vm_lifetime: 12
   vm_lifetime_auth: 24
   allowed_tags:


### PR DESCRIPTION
This commit fixes checking of a VM that has already been identified as ready. Without this change a ready VM that has failed will be identified as having failed, but will not successfully be removed from the ready queue. Additionally, the default vm_checktime value has been reduced from 15 to 1 to ensure that ready VMs are checked within one minute of the time they have reached the ready state by default.

Lastly, the docker-compose files are updated to specify that the redis
instance used is a local redis instance.