### PR TITLE
(POOLER-134) Ship VM usage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ git logs & PR history.
 - Remove a failed VM from the ready queue (POOLER-133)
 - Begin checking ready VMs to ensure alive after 1 minute by default
 
+### Added
+- Add capability to ship VM usage metrics (POOLER-134)
+
 # [0.2.2](https://github.com/puppetlabs/vmpooler/compare/0.2.1...0.2.2)
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -156,6 +156,20 @@ When enabled in the global configuration then purging is enabled for all provide
 Expects a boolean value
 (optional; default: false)
 
+### USAGE\_STATS
+
+Enable shipping of VM usage stats
+When enabled a metric is emitted when a machine is destroyed. Tags are inspected and used to organize
+shipped metrics if there is a jenkins\_build\_url tag set for the VM.
+Without the jenkins\_build\_url tag set the metric will be sent as "usage.$user.$pool\_name".
+When the jenkins\_build\_url tag is set the metric will be sent with additional data. Here is an example
+based off of the following URL;
+https://jenkins.example.com/job/platform\_puppet-agent-extra\_puppet-agent-integration-suite\_pr/RMM\_COMPONENT\_TO\_TEST\_NAME=puppet,SLAVE\_LABEL=beaker,TEST\_TARGET=redhat7-64a/824/
+"usage.$user.$instance.$value\_stream.$branch.$project.$job\_name.$component\_to\_test.$pool\_name", which translates to
+"usage.$user.jenkins\_example\_com.platform.pr.puppet-agent-extra.puppet-agent-integration-suite.puppet.$pool\_name"
+Expects a boolean value
+(optional; default: false)
+
 ## API options <a name="API"></a>
 
 ### AUTH\_PROVIDER

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -66,6 +66,7 @@ module Vmpooler
     parsed_config[:config]['create_template_delta_disks'] = ENV['CREATE_TEMPLATE_DELTA_DISKS'] if ENV['CREATE_TEMPLATE_DELTA_DISKS']
     parsed_config[:config]['experimental_features'] = ENV['EXPERIMENTAL_FEATURES'] if ENV['EXPERIMENTAL_FEATURES']
     parsed_config[:config]['purge_unconfigured_folders'] = ENV['PURGE_UNCONFIGURED_FOLDERS'] if ENV['PURGE_UNCONFIGURED_FOLDERS']
+    parsed_config[:config]['usage_stats'] = ENV['USAGE_STATS'] if ENV['USAGE_STATS']
 
     parsed_config[:redis] = parsed_config[:redis] || {}
     parsed_config[:redis]['server'] = ENV['REDIS_SERVER'] || parsed_config[:redis]['server'] || 'localhost'

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -45,10 +45,11 @@ def create_ready_vm(template, name, token = nil)
   redis.hset("vmpooler__vm__#{name}", "template", template)
 end
 
-def create_running_vm(template, name, token = nil)
-  create_vm(name, token)
+def create_running_vm(template, name, token = nil, user = nil)
+  create_vm(name, token, nil, user)
   redis.sadd("vmpooler__running__#{template}", name)
-  redis.hset("vmpooler__vm__#{name}", "template", template)
+  redis.hset("vmpooler__vm__#{name}", 'template', template)
+  redis.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
 end
 
 def create_pending_vm(template, name, token = nil)
@@ -57,10 +58,11 @@ def create_pending_vm(template, name, token = nil)
   redis.hset("vmpooler__vm__#{name}", "template", template)
 end
 
-def create_vm(name, token = nil, redis_handle = nil)
+def create_vm(name, token = nil, redis_handle = nil, user = nil)
   redis_db = redis_handle ? redis_handle : redis
   redis_db.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
   redis_db.hset("vmpooler__vm__#{name}", 'token:token', token) if token
+  redis_db.hset("vmpooler__vm__#{name}", 'token:user', user) if user
 end
 
 def create_completed_vm(name, pool, active = false, redis_handle = nil)
@@ -79,6 +81,11 @@ def create_migrating_vm(name, pool, redis_handle = nil)
   redis_db = redis_handle ? redis_handle : redis
   redis_db.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
   redis_db.sadd("vmpooler__migrating__#{pool}", name)
+end
+
+def create_tag(vm, tag_name, tag_value, redis_handle = nil)
+  redis_db = redis_handle ? redis-handle : redis
+  redis_db.hset("vmpooler__vm__#{vm}", "tag:#{tag_name}", tag_value)
 end
 
 def add_vm_to_migration_set(name, redis_handle = nil)

--- a/spec/unit/providers_spec.rb
+++ b/spec/unit/providers_spec.rb
@@ -17,7 +17,7 @@ describe 'providers' do
         File.join(project_root_dir, 'lib', 'vmpooler', 'providers', 'dummy.rb'),
         File.join(project_root_dir, 'lib', 'vmpooler', 'providers', 'vsphere.rb')
     ]
-    expect(Vmpooler::Providers.load_all_providers).to eq(p)
+    expect(Vmpooler::Providers.load_all_providers).to match_array(p)
   end
 
   it '#installed_providers' do
@@ -43,7 +43,7 @@ describe 'providers' do
         File.join(project_root_dir, 'lib', 'vmpooler', 'providers', 'dummy.rb'),
         File.join(project_root_dir, 'lib', 'vmpooler', 'providers', 'vsphere.rb')
     ]
-    expect(providers.load_from_gems).to eq(p)
+    expect(providers.load_from_gems).to match_array(p)
 
   end
 

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -485,6 +485,19 @@
 #     Expects a hash value
 #     (optional)
 #
+#   - usage_stats
+#     Enable shipping of VM usage stats
+#     When enabled a metric is emitted when a machine is destroyed. Tags are inspected and used to organize
+#     shipped metrics if there is a jenkins_build_url tag set for the VM.
+#     Without the jenkins_build_url tag set the metric will be sent as "usage.$user.$pool_name".
+#     When the jenkins_build_url tag is set the metric will be sent with additional data. Here is an example
+#     based off of the following URL, and requested by the user ABS;
+#     https://jenkins.example.com/job/platform_puppet-agent-extra_puppet-agent-integration-suite_pr/RMM_COMPONENT_TO_TEST_NAME=puppet,SLAVE_LABEL=beaker,TEST_TARGET=redhat7-64a/824/
+#     "usage.$user.$instance.$value_stream.$branch.$project.$job_name.$component_to_test.$pool_name", which translates to
+#     "usage.$user.jenkins_example_com.platform.pr.puppet-agent-extra.puppet-agent-integration-suite.puppet.$pool_name"
+#     Expects a boolean value
+#     (optional; default: false)
+#
 # Example:
 
 :config:


### PR DESCRIPTION
This commit updates vmpooler to ship VM usage stats when a VM is destroyed. The stats are gathered for jobs based on user and pool name. If a jenkins build URL is present then this is broken down by user, instance, value stream, branch and project. Additionally, if present then the RMM_COMPONENT_TO_TEST_NAME will be listed after project. Without this change we do not collect stats on per VM usage and its correlation to users and pools.