### PR TITLE
Ensure nodes are consistent for usage stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.2.3...master)
 
+### Fixed
+- Ensure that metric nodes for vm usage stats are consistent
+
 # [0.2.3](https://github.com/puppetlabs/vmpooler/compare/0.2.2...0.2.3)
 
 ### Fixed

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -333,12 +333,13 @@ module Vmpooler
       poolname = $redis.hget("vmpooler__vm__#{vm}", "template")
 
       unless jenkins_build_url
+        user = user.gsub('.', '_')
         $metrics.increment("usage.#{user}.#{poolname}")
         return
       end
 
       url_parts = jenkins_build_url.split('/')[2..-1]
-      instance = url_parts[0].gsub('.', '_')
+      instance = url_parts[0]
       value_stream_parts = url_parts[2].split('_')
       value_stream = value_stream_parts.shift
       branch = value_stream_parts.pop
@@ -360,6 +361,7 @@ module Vmpooler
       ]
 
       metric_parts = metric_parts.reject { |s| s.nil? }
+      metric_parts = metric_parts.map { |s| s.gsub('.', '_') }
 
       $metrics.increment(metric_parts.join('.'))
     rescue => err


### PR DESCRIPTION
This commit updates vm usage stats collection to replace all instances of '.' characters within node strings. Without this change the node string containing a '.' character causes the metric to be interpreted as containing another node.