### PR TITLE
Stop testing ruby 2.3.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,19 +6,13 @@ services:
 
 matrix:
   include:
-    - rvm: 2.3.8
+    - rvm: 2.4.5
       env: "CHECK=rubocop"
-
-    - rvm: 2.3.8
-      env: "CHECK=test"
 
     - rvm: 2.4.5
       env: "CHECK=test"
 
     - rvm: 2.5.3
-      env: "CHECK=test"
-
-    - rvm: jruby-9.1.17.0
       env: "CHECK=test"
 
     - rvm: jruby-9.2.5.0
@@ -27,7 +21,7 @@ matrix:
   # Remove the allow_failures section once
   # Rubocop is required for Travis to pass a build
   allow_failures:
-    - rvm: 2.3.8
+    - rvm: 2.4.5
       env: "CHECK=rubocop"
 
 install:


### PR DESCRIPTION
This commit updates travis configuration to stop testing 2.3.x and jruby 9.1.x. Without this change tests fail due to library incompatibilities with ruby 2.3.x.