### PR TITLE
Update dockerfile jruby to 9.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 # RUN:
 #   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 
-FROM jruby:9.1-jdk
+FROM jruby:9.2-jdk
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 

--- a/docker/Dockerfile-aio
+++ b/docker/Dockerfile-aio
@@ -8,7 +8,7 @@
 # RUN:
 #   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 
-FROM jruby:9.1-jdk
+FROM jruby:9.2-jdk
 
 RUN mkdir -p /var/lib/vmpooler
 

--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -8,7 +8,7 @@
 # RUN:
 #   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 
-FROM jruby:9.1-jdk
+FROM jruby:9.2-jdk
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 COPY ./ ./


### PR DESCRIPTION
This commit updates jruby in dockerfiles from 9.1 to 9.2. Without this change the dockerfiles use a version of ruby that is no longer tested with vmpooler.