### PR TITLE
(POOLER-138) Support multiple pools per alias

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 cache: bundler
 sudo: false
 language: ruby
-services:
-  - redis-server
 
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ git logs & PR history.
 
 ### Fixed
  - Improve support for configuration via environment variables (POOLER-137)
+ - Support multiple pool backends per alias (POOLER-138)
+ - Remove redis server testing requirement
 
 # [0.3.0](https://github.com/puppetlabs/vmpooler/compare/0.2.2...0.3.0)
 

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -108,10 +108,11 @@ module Vmpooler
       parsed_config[:pool_names] << pool['name']
       if pool['alias']
         if pool['alias'].is_a?(Array)
-          pool['alias'].each do |a|
+          pool['alias'].each do |pool_alias|
             parsed_config[:alias] ||= {}
-            parsed_config[:alias][a] = pool['name']
-            parsed_config[:pool_names] << a
+            parsed_config[:alias][pool_alias] = [pool['name']] unless parsed_config[:alias].key? pool_alias
+            parsed_config[:alias][pool_alias] << pool['name'] unless parsed_config[:alias][pool_alias].include? pool['name']
+            parsed_config[:pool_names] << pool_alias
           end
         elsif pool['alias'].is_a?(String)
           parsed_config[:alias][pool['alias']] = pool['name']

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -40,8 +40,8 @@ module Vmpooler
       template_backends = [template]
       aliases = Vmpooler::API.settings.config[:alias]
       if aliases
-        template_backends << aliases[template] if aliases[template]
-
+        template_backends = template_backends + aliases[template] if aliases[template].is_a?(Array)
+        template_backends << aliases[template] if aliases[template].is_a?(String)
         pool_index = pool_index(pools)
         weighted_pools = {}
         template_backends.each do |t|
@@ -61,7 +61,9 @@ module Vmpooler
           template_backends.delete(selection)
           template_backends.unshift(selection)
         else
-          template_backends = template_backends.sample(template_backends.count)
+          first = template_backends.sample
+          template_backends.delete(first)
+          template_backends.unshift(first)
         end
       end
 

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -1,7 +1,8 @@
+require 'mock_redis'
+
 def redis
   unless @redis
-    @redis = Redis.new
-    @redis.select(15) # let's use the highest numbered database available in a default install
+    @redis = MockRedis.new
   end
   @redis
 end

--- a/spec/integration/api/v1/config_spec.rb
+++ b/spec/integration/api/v1/config_spec.rb
@@ -32,8 +32,6 @@ describe Vmpooler::API::V1 do
     let(:current_time) { Time.now }
 
     before(:each) do
-      redis.flushdb
-
       app.settings.set :config, config
       app.settings.set :redis, redis
       app.settings.set :metrics, metrics

--- a/spec/integration/api/v1/status_spec.rb
+++ b/spec/integration/api/v1/status_spec.rb
@@ -32,8 +32,6 @@ describe Vmpooler::API::V1 do
     let(:current_time) { Time.now }
 
     before(:each) do
-      redis.flushdb
-
       app.settings.set :config, config
       app.settings.set :redis, redis
       app.settings.set :config, auth: false

--- a/spec/integration/api/v1/vm_hostname_spec.rb
+++ b/spec/integration/api/v1/vm_hostname_spec.rb
@@ -32,8 +32,6 @@ describe Vmpooler::API::V1 do
     let(:current_time) { Time.now }
 
     before(:each) do
-      redis.flushdb
-
       app.settings.set :config, config
       app.settings.set :redis, redis
       app.settings.set :config, auth: false

--- a/spec/integration/api/v1/vm_template_spec.rb
+++ b/spec/integration/api/v1/vm_template_spec.rb
@@ -30,8 +30,6 @@ describe Vmpooler::API::V1 do
     let(:current_time) { Time.now }
 
     before(:each) do
-      redis.flushdb
-
       app.settings.set :config, config
       app.settings.set :redis, redis
       app.settings.set :metrics, metrics

--- a/spec/integration/dashboard_spec.rb
+++ b/spec/integration/dashboard_spec.rb
@@ -10,10 +10,6 @@ describe Vmpooler::API do
 
   describe 'Dashboard' do
 
-    before(:each) do
-      redis.flushdb
-    end
-
     context '/' do
       before { get '/' }
 


### PR DESCRIPTION
This change updates handling of pool aliases to allow for more than a
single pool to be configured as an alias pool. Without this change if
multiple pools are configured as an alias the last one to configure it
is set as the alias for that pool.

Additionally, redis testing requirements are removed in favor of
mock_redis. Without this change a redis server is required to run
vmpooler tests.