### PR TITLE
Fix Dockerfile link in readme and add note about http requests for dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ See the provided YAML configuration example, [vmpooler.yaml.example](vmpooler.ya
 
 ### Running via Docker
 
-A [Dockerfile](Dockerfile) is included in this repository to allow running vmpooler inside a Docker container. A configuration file can be used via volume mapping, and specifying the destination as the configuration file via environment variables, or the application can be configured with environment variables alone. The Dockerfile provides an entrypoint so you may choose whether to run API, or manager services. The default behavior will run both. To build and run:
+A [Dockerfile](/docker/Dockerfile) is included in this repository to allow running vmpooler inside a Docker container. A configuration file can be used via volume mapping, and specifying the destination as the configuration file via environment variables, or the application can be configured with environment variables alone. The Dockerfile provides an entrypoint so you may choose whether to run API, or manager services. The default behavior will run both. To build and run:
 
 ```
 docker build -t vmpooler . && docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler

--- a/vmpooler.yaml.dummy-example
+++ b/vmpooler.yaml.dummy-example
@@ -24,6 +24,7 @@
     - 'created_by'
     - 'project'
   domain: 'example.com'
+  #domain: 'localhost' # Flip these out for local requests
   prefix: 'poolvm-'
 
 :pools:


### PR DESCRIPTION
This pull request fixes up a dead link in the README to the Dockerfile, and also leaves a note in the dummy example config about making HTTP requests locally.