### PR TITLE
Fixup docker mount error

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -7,8 +7,8 @@ services:
       dockerfile: docker/Dockerfile_local
     volumes:
       - type: bind
-        source: ${PWD}/vmpooler.yaml
-        target: /etc/vmpooler/vmpooler.yaml
+        source: ${PWD}
+        target: /etc/vmpooler
     ports:
       - "4567:4567"
     networks:


### PR DESCRIPTION
Prior to this commit, docker compose couldn't mount a file to a dir on
the container. This commit fixes that up by mounting the projects src
dir to the vmpoolers config location.

With how the compose file is now, it fails to properly mount a file as a directory:

```
brian@localghost:vmpooler % docker-compose -f docker/docker-compose.yml up                                    ±[fixup]
docker_redislocal_1 is up-to-date
Starting docker_vmpooler_1 ...
Starting docker_vmpooler_1 ... error

ERROR: for docker_vmpooler_1  Cannot start service vmpooler: OCI runtime create failed: container_linux.go:344: starting container process caused "process_linux.go:424: container init caused \"rootfs_linux.go:58: mounting \\\"/home/brian/code/vmpooler/vmpooler.yaml\\\" to rootfs \\\"/var/lib/docker/overlay2/9ce492cd9e84d8947964f9e67cbaa4dde4d414f7e6506ec71224aa2bde27787b/merged\\\" at \\\"/var/lib/docker/overlay2/9ce492cd9e84d8947964f9e67cbaa4dde4d414f7e6506ec71224aa2bde27787b/merged/etc/vmpooler/vmpooler.yaml\\\" caused \\\"not a directory\\\"\"": unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type

ERROR: for vmpooler  Cannot start service vmpooler: OCI runtime create failed: container_linux.go:344: starting container process caused "process_linux.go:424: container init caused \"rootfs_linux.go:58: mounting \\\"/home/brian/code/vmpooler/vmpooler.yaml\\\" to rootfs \\\"/var/lib/docker/overlay2/9ce492cd9e84d8947964f9e67cbaa4dde4d414f7e6506ec71224aa2bde27787b/merged\\\" at \\\"/var/lib/docker/overlay2/9ce492cd9e84d8947964f9e67cbaa4dde4d414f7e6506ec71224aa2bde27787b/merged/etc/vmpooler/vmpooler.yaml\\\" caused \\\"not a directory\\\"\"": unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
```

Ideally, it could be moved into a `config` folder and then all of the example config files could move into there, but I didn't want to change or break other potential workflows that might assume having a vmpooler config in the source directory, but I'm happy to fix it up to work that way if it's agreeable.