### PR TITLE
(POOLER-139) Fix discovering checked out VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ The format is based on
 Tracking in this Changelog began for this project with the tagging of version 0.1.0.
 If you're looking for changes from before this, refer to the project's
 git logs & PR history.
-# [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.4.0...master)
+# [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.5.0...master)
+
+# [0.5.0](https://github.com/puppetlabs/vmpooler/compare/0.4.0...0.5.0)
+
+### Fixed
+ - Eliminate window for checked out VM to be discovered (POOLER-139)
 
 # [0.4.0](https://github.com/puppetlabs/vmpooler/compare/0.3.0...0.4.0)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,12 +10,14 @@
 
 FROM jruby:9.2-jdk
 
+ARG vmpooler_version=0.5.0
+
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 
 ENV LOGFILE=/dev/stdout \
       RACK_ENV=production
 
-RUN gem install vmpooler && \
+RUN gem install vmpooler -v ${vmpooler_version} && \
       chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
This commit updates how vmpooler retrieves VMs to add a VM to the running queue as soon as it is checked out. Without this change it is possible that a VM can be discovered when it is checked out before it is added to the running queue if multiple systems are requested. Additionally, the dockerfile is updated to support specifying the version of vmpooler to install.