### PR TITLE
Improve cluster lookup

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -839,7 +839,9 @@ module Vmpooler
         def find_cluster(cluster, connection, datacentername)
           datacenter = connection.serviceInstance.find_datacenter(datacentername)
           raise("Datacenter #{datacentername} does not exist") if datacenter.nil?
-          datacenter.hostFolder.children.find { |cluster_object| cluster_object.name == cluster }
+          found_cluster = datacenter.hostFolder.traverse(cluster)
+          raise("Cluster #{cluster} could not be found or does not exist") if not found_cluster.is_a? RbVmomi::VIM::ClusterComputeResource
+          found_cluster
         end
 
         def get_cluster_host_utilization(cluster, model = nil)


### PR DESCRIPTION
Without this commit, cluster lookup was done by traversing the first
level below a given datacenter and comparing the names of the objects
present there. Though uncommon, entities at this level may be folders
that contain the sought after cluster. To make matters worse, a non
cluster entity may have the exact same name as the cluster being looked
up. Matching is performed by comparing only entity name and thus a
folder entity may be mistakenly returned if it matches the name provided
for lookup. Traversal into the folder entity is impossible. There is no
error checking or helpful output to determine the issue.

This commit changes the method by which cluster lookup is performed. It
assumes that, as before, the cluster name will be provided as a string
and it will be looked up by that string. However the string can be a
relative entity path as well used to traverse a folder entity. The new
lookup uses the #traverse() method from the datacenter entity to find
the cluster entity. There is also some simple return type checking to
tell if what we found in the traversal is a
`RbVmomi::VIM::ClusterComputeResource` object. If not, a basic
indication of the problem is raised to the user.