### PR TITLE
(MAINT) Add bundler to dockerfile_local

### DIFF
--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -15,7 +15,7 @@ COPY ./ ./
 
 ENV RACK_ENV=production
 
-RUN bundle && gem build vmpooler.gemspec && gem install vmpooler*.gem && \
+RUN gem install bundler && bundle && gem build vmpooler.gemspec && gem install vmpooler*.gem && \
       chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
This commit adds bundler to dockerfile_local in order to support building vmpooler. Without this change the dockerfile_local build fails reporting bundler is not available.