### PR TITLE
(QENG-7201) Vmpooler pool statistic endpoint optimization

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -629,6 +629,52 @@ The valid sections are "boot", "clone" or "tag" eg. `vmpooler.example.com/api/v1
 You can further drill-down the data by specifying the second level parameter to query eg
 `vmpooler.example.com/api/v1/summary/tag/created_by`
 
+##### GET /poolstat?pool=FOO
+
+For parameter `pool`, containing a comma separated list of pool names to query, this endpoint returns
+each of the pool's ready, max and alias information. It can be used to get a fast response for
+the required pools instead of using the /status API endpoint
+
+Return codes
+* 200  OK 
+
+```
+$ curl https://vmpooler.example.com/api/v1/poolstat?pool=centos-6-x86_64
+```
+```json
+{
+  "pools": {
+    "centos-6-x86_64": {
+      "ready": 25,
+      "max": 25,
+      "alias": [
+        "centos-6-64",
+        "centos-6-amd64"
+      ]
+    }
+  }
+}
+```
+
+##### GET /totalrunning
+
+Fast endpoint to return the total number of VMs in a 'running' state
+
+Return codes
+* 200  OK 
+
+```
+$ curl https://vmpooler.example.com/api/v1/totalrunning
+```
+
+```json
+{
+
+  "running": 362
+
+}
+```
+
 #### Managing pool configuration via API <a name="poolconfig"></a>
 
 ##### GET /config

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -354,7 +354,15 @@ module Vmpooler
       if params[:pool]
         subpool = params[:pool].split(",")
         poolscopy = pools.select do |p|
-          subpool.include?(p['name']) || (p['alias'] & subpool).any?
+          if subpool.include?(p['name'])
+            true
+          elsif !p['alias'].nil?
+            if p['alias'].is_a?(Array)
+              (p['alias'] & subpool).any?
+            elsif p['alias'].is_a?(String)
+              subpool.include?(p['alias'])
+            end
+          end
         end
       end
 

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -341,6 +341,71 @@ module Vmpooler
       JSON.pretty_generate(Hash[result.sort_by { |k, _v| k }])
     end
 
+    # request statistics for specific pools by passing parameter 'pool'
+    # with a coma separated list of pools we want to query ?pool=ABC,DEF
+    # returns the ready, max numbers and the aliases (if set)
+    get "#{api_prefix}/poolstat/?" do
+      content_type :json
+
+      result = {}
+
+      poolscopy = []
+
+      if params[:pool]
+        subpool = params[:pool].split(",")
+        poolscopy = pools.select do |p|
+          subpool.include?(p['name']) || (p['alias'] & subpool).any?
+        end
+      end
+
+      result[:pools] = {}
+
+      poolscopy.each do |pool|
+        result[:pools][pool['name']] = {}
+
+        max      = pool['size']
+        aka      = pool['alias']
+
+        result[:pools][pool['name']][:max] = max
+
+        if aka
+          result[:pools][pool['name']][:alias] = aka
+        end
+
+      end
+
+      # using pipelined is much faster than querying each of the pools
+      res = backend.pipelined do
+        poolscopy.each do |pool|
+          backend.scard('vmpooler__ready__' + pool['name'])
+        end
+      end
+
+      res.each_with_index { |ready, i| result[:pools][poolscopy[i]['name']][:ready] = ready }
+
+      JSON.pretty_generate(Hash[result.sort_by { |k, _v| k }])
+    end
+
+    # requests the total number of running VMs
+    get "#{api_prefix}/totalrunning/?" do
+      content_type :json
+      queue = {
+          running:   0,
+      }
+
+      # using pipelined is much faster than querying each of the pools and adding them
+      # as we get the result.
+      res = backend.pipelined do
+        pools.each do |pool|
+          backend.scard('vmpooler__running__' + pool['name'])
+        end
+      end
+
+      queue[:running] = res.inject(0){ |m, x| m+x }
+
+      JSON.pretty_generate(queue)
+    end
+
     get "#{api_prefix}/summary/?" do
       content_type :json
 


### PR DESCRIPTION
Before this change we used the API /status endpoint to get specific information
on pools such as the number of ready VMs and the max.
This commit creates two new endpoints to get to that information much quicker
1) poolstat?pool= takes a comma separated list of pools to return, and will provide
the max, ready and alias values.
2) /totalrunning will calculate the total number of running VMs across all pools
It also uses the redis pipeline mode to speed up the DB requests.