### PR TITLE
(POOLER-140) Fix typo in domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.6.1...master)
 
+### Added
+- Validate a machine responds to vm\_ready? at checkout (POOLER-140)
+
 # [0.6.1](https://github.com/puppetlabs/vmpooler/compare/0.6.0...0.6.1)
 
 ### Added

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -71,7 +71,7 @@ module Vmpooler
         vms = backend.smembers("vmpooler__ready__#{template_backend}")
         next if vms.empty?
         vms.reverse.each do |vm|
-          ready = vm_ready?(vm, config[:domain])
+          ready = vm_ready?(vm, config['domain'])
           if ready
             backend.smove("vmpooler__ready__#{template_backend}", "vmpooler__running__#{template_backend}", vm)
             return [vm, template_backend, template]


### PR DESCRIPTION
This commit updates the reference to domain from vmpooler config. Without this change the domain value is read as an empty string and breaks checkouts.