### PR TITLE
Make it possible to disable linked clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,15 @@ The format is based on
 Tracking in this Changelog began for this project with the tagging of version 0.1.0.
 If you're looking for changes from before this, refer to the project's
 git logs & PR history.
-# [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.6.2...master)
+# [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.6.3...master)
+
+### Added
+- Add capability to disable linked clones for vsphere provider
+
+# [0.6.3](https://github.com/puppetlabs/vmpooler/compare/0.6.2...0.6.3)
+
+### Added
+- Add capability to configure pool cluster via config api (POOLER-143)
 
 # [0.6.2](https://github.com/puppetlabs/vmpooler/compare/0.6.1...0.6.2)
 

--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -15,7 +15,7 @@ COPY ./ ./
 
 ENV RACK_ENV=production
 
-RUN gem install bundler -v '2.0.1' && bundle install && gem build vmpooler.gemspec && gem install vmpooler*.gem && \
+RUN gem install bundler && bundle install && gem build vmpooler.gemspec && gem install vmpooler*.gem && \
       chmod +x /usr/local/bin/docker-entrypoint.sh
 
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -147,6 +147,12 @@ Note: this will only create the last folder when it does not exist. It will not 
 Create backing delta disks for the specified templates to support creating linked clones.
 (optional; default: false)
 
+### CREATE\_LINKED\_CLONES
+
+Whether to create linked clone virtual machines when using the vsphere provider.
+This can also be set per pool.
+(optional; default: true)
+
 ### PURGE\_UNCONFIGURED\_FOLDERS
 
 Enable purging of VMs and folders detected within the base folder path that are not configured for the provider

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -64,6 +64,7 @@ module Vmpooler
     parsed_config[:config]['retry_factor'] = string_to_int(ENV['RETRY_FACTOR']) if ENV['RETRY_FACTOR']
     parsed_config[:config]['create_folders'] = ENV['CREATE_FOLDERS'] if ENV['CREATE_FOLDERS']
     parsed_config[:config]['create_template_delta_disks'] = ENV['CREATE_TEMPLATE_DELTA_DISKS'] if ENV['CREATE_TEMPLATE_DELTA_DISKS']
+    set_linked_clone(parsed_config)
     parsed_config[:config]['experimental_features'] = ENV['EXPERIMENTAL_FEATURES'] if ENV['EXPERIMENTAL_FEATURES']
     parsed_config[:config]['purge_unconfigured_folders'] = ENV['PURGE_UNCONFIGURED_FOLDERS'] if ENV['PURGE_UNCONFIGURED_FOLDERS']
     parsed_config[:config]['usage_stats'] = ENV['USAGE_STATS'] if ENV['USAGE_STATS']
@@ -182,5 +183,15 @@ module Vmpooler
     return if s.nil?
     return unless s =~ /\d/
     return Integer(s)
+  end
+
+  def self.true?(obj)
+    obj.to_s.downcase == "true"
+  end
+
+  def self.set_linked_clone(parsed_config)
+    parsed_config[:config]['create_linked_clones'] = parsed_config[:config]['create_linked_clones'] || true
+    parsed_config[:config]['create_linked_clones'] = ENV['CREATE_LINKED_CLONES'] if ENV['CREATE_LINKED_CLONES'] =~ /true|false/
+    parsed_config[:config]['create_linked_clones'] = true?(parsed_config[:config]['create_linked_clones']) if parsed_config[:config]['create_linked_clones']
   end
 end

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -312,7 +312,7 @@ module Vmpooler
             # Put the VM in the specified folder and resource pool
             relocate_spec = RbVmomi::VIM.VirtualMachineRelocateSpec(
               datastore: find_datastore(target_datastore, connection, target_datacenter_name),
-              diskMoveType: :moveChildMostDiskBacking
+              diskMoveType: get_disk_backing(pool)
             )
 
             manage_host_selection = @config[:config]['manage_host_selection'] if @config[:config].key?('manage_host_selection')
@@ -1027,6 +1027,17 @@ module Vmpooler
           return false if template[0] == '/'
           return false if template[-1] == '/'
           return true
+        end
+
+        def get_disk_backing(pool)
+          return :moveChildMostDiskBacking if linked_clone?(pool)
+          return :moveAllDiskBackingsAndConsolidate
+        end
+
+        def linked_clone?(pool)
+          return if pool[:create_linked_clone] == false
+          return true if pool[:create_linked_clone]
+          return true if @config[:config]['create_linked_clones']
         end
       end
     end

--- a/spec/unit/env_config.rb
+++ b/spec/unit/env_config.rb
@@ -26,6 +26,7 @@ describe 'Vmpooler' do
         ['clone_target', test_string, nil],
         ['create_folders', test_bool, nil],
         ['create_template_delta_disks', test_bool, nil],
+        ['create_linked_clones', test_bool, nil],
         ['experimental_features', test_bool, nil],
         ['purge_unconfigured_folders', test_bool, nil],
         ['usage_stats', test_bool, nil],

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -3431,4 +3431,29 @@ EOT
       end
     end
   end
+
+  describe 'get_disk_backing' do
+
+    it 'should return moveChildMostDiskBacking when linked clone enabled' do
+      expect( subject.get_disk_backing({create_linked_clone: true}) ).to eq(:moveChildMostDiskBacking)
+    end
+
+    it 'should return moveAllDiskBackingsAndConsolidate when no preference is specified' do
+      expect( subject.get_disk_backing({})).to eq(:moveAllDiskBackingsAndConsolidate)
+    end
+
+    it 'should return moveAllDiskBackingsAndConsolidate when linked clone is false' do
+      expect( subject.get_disk_backing({create_linked_clone: false})).to eq(:moveAllDiskBackingsAndConsolidate)
+    end
+  end
+
+  describe 'linked_clone?' do
+    it 'should return true when linked clone is enabled on the pool' do
+      expect( subject.linked_clone?({create_linked_clone: true}) ).to be true
+    end
+
+    it 'should return nil when linked clone is not enabled on the pool' do
+      expect( subject.linked_clone?({}) ).to be nil
+    end
+  end
 end

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -592,6 +592,7 @@
     timeout: 15
     ready_ttl: 1440
     provider: vsphere
+    create_linked_clone: true
   - name: 'debian-7-x86_64'
     alias: [ 'debian-7-64', 'debian-7-amd64' ]
     template: 'Templates/debian-7-x86_64'
@@ -601,3 +602,4 @@
     timeout: 15
     ready_ttl: 1440
     provider: vsphere
+    create_linked_clone: false


### PR DESCRIPTION
This commit adds a new configuration parameter to allow setting whether to create linked clones on a global, or per pool basis. Without this change vmpooler would always attempt to create linked clones. The default behavior of creating linked clones is preserved.