### PR TITLE
(POOLER-142) Add running host to vm API data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ git logs & PR history.
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.6.3...master)
 
 ### Added
-- Add capability to disable linked clones for vsphere provider
+- Add capability to disable linked clones for vsphere provider (POOLER-147)
+- Add running host to VM data returned from /vm/hostname (POOLER-142)
 
 # [0.6.3](https://github.com/puppetlabs/vmpooler/compare/0.6.2...0.6.3)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -226,7 +226,9 @@ $ curl --url vmpooler.example.com/api/v1/vm/pxpmtoonx7fiqg6
       "user": "jdoe"
     },
     "ip": "192.168.0.1",
-    "domain": "example.com"
+    "domain": "example.com",
+    "host": "host1.example.com",
+    "migrated": "true"
   }
 }
 ```

--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -829,6 +829,10 @@ module Vmpooler
         if config['domain']
           result[params[:hostname]]['domain'] = config['domain']
         end
+
+        result[params[:hostname]]['host'] = rdata['host'] if rdata['host']
+        result[params[:hostname]]['migrated'] = rdata['migrated'] if rdata['migrated']
+
       end
 
       JSON.pretty_generate(result)

--- a/spec/helpers.rb
+++ b/spec/helpers.rb
@@ -51,6 +51,7 @@ def create_running_vm(template, name, token = nil, user = nil)
   redis.sadd("vmpooler__running__#{template}", name)
   redis.hset("vmpooler__vm__#{name}", 'template', template)
   redis.hset("vmpooler__vm__#{name}", 'checkout', Time.now)
+  redis.hset("vmpooler__vm__#{name}", 'host', 'host1')
 end
 
 def create_pending_vm(template, name, token = nil)

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -53,6 +53,7 @@ describe Vmpooler::API::V1 do
         expect(response_body["end_time"]).to eq(current_time.to_datetime.rfc3339)
         expect(response_body["state"]).to eq("running")
         expect(response_body["ip"]).to eq("")
+        expect(response_body["host"]).to eq("host1")
       end
     end
 


### PR DESCRIPTION
This change adds the running host for a VM to the API data available via /vm/hostname. Without this change the running host would be logged to vmpooler log, but not available any other way. Additionally, the data will specify if a machine has been migrated. Without this change parent host data for a vmpooler machine is not available via the vmpooler API.