### PR TITLE
(POOLER-147) Fix create_linked_clone pool option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ If you're looking for changes from before this, refer to the project's
 git logs & PR history.
 # [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.7.0...master)
 
+### Fixed
+- Correctly detect create\_linked\_clone on a pool level (POOLER-147)
+
 # [0.7.0](https://github.com/puppetlabs/vmpooler/compare/0.6.3...0.7.0)
 
 ### Added

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -1037,8 +1037,8 @@ module Vmpooler
         end
 
         def linked_clone?(pool)
-          return if pool[:create_linked_clone] == false
-          return true if pool[:create_linked_clone]
+          return if pool['create_linked_clone'] == false
+          return true if pool['create_linked_clone']
           return true if @config[:config]['create_linked_clones']
         end
       end

--- a/spec/unit/providers/vsphere_spec.rb
+++ b/spec/unit/providers/vsphere_spec.rb
@@ -59,6 +59,7 @@ describe 'Vmpooler::PoolManager::Provider::VSphere' do
     # Drop the connection pool timeout way down for spec tests so they fail fast
     connection_pool_timeout: 1
     datacenter: MockDC
+    create_linked_clones: true
 :pools:
   - name: '#{poolname}'
     alias: [ 'mockpool' ]
@@ -3439,7 +3440,7 @@ EOT
   describe 'get_disk_backing' do
 
     it 'should return moveChildMostDiskBacking when linked clone enabled' do
-      expect( subject.get_disk_backing({create_linked_clone: true}) ).to eq(:moveChildMostDiskBacking)
+      expect( subject.get_disk_backing({'create_linked_clone' => true}) ).to eq(:moveChildMostDiskBacking)
     end
 
     it 'should return moveAllDiskBackingsAndConsolidate when no preference is specified' do
@@ -3453,7 +3454,7 @@ EOT
 
   describe 'linked_clone?' do
     it 'should return true when linked clone is enabled on the pool' do
-      expect( subject.linked_clone?({create_linked_clone: true}) ).to be true
+      expect( subject.linked_clone?({'create_linked_clone' => true}) ).to be true
     end
 
     it 'should return nil when linked clone is not enabled on the pool' do


### PR DESCRIPTION
This commit updates the create_linked_clone pool option to correctly detect when linked clones have been set at a pool level. Without this change a pool setting create_linked_clone to false is not interpreted correctly, and a linked clone is created if possible.