### PR TITLE
(POOLER-148) Fix undefined variable bug in _check_ready_vm.

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -156,7 +156,7 @@ module Vmpooler
         $redis.hset('vmpooler__vm__' + vm, 'check', Time.now)
         # Check if the hosts TTL has expired
         if ttl > 0
-          # 'boottime' may be nil if host is not powered on
+          # if 'boottime' is nil, set bootime to beginning of unix epoch, forces TTL to be assumed expired
           boottime = $redis.hget("vmpooler__vm__#{vm}", 'ready')
           if boottime
             boottime = Time.parse(boottime)


### PR DESCRIPTION
The host['boottime'] variable in the function _check_ready_vm no longer
has its parent object in reference due to the refactoring in pull
request #269.  So in order to get the same information without the
performance impact from duplicate object lookups, we get similar
information from the time that the VM is ready.