### PR TITLE
(POOLER-150) Synchronize checkout operations for API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ git logs & PR history.
 
 ### Fixed
 - Correctly detect create\_linked\_clone on a pool level (POOLER-147)
+- Ensure that checkout operations are synchronized
 
 # [0.7.0](https://github.com/puppetlabs/vmpooler/compare/0.6.3...0.7.0)
 

--- a/bin/vmpooler
+++ b/bin/vmpooler
@@ -24,7 +24,8 @@ if torun.include? 'api'
   api = Thread.new do
     thr = Vmpooler::API.new
     redis = Vmpooler.new_redis(redis_host, redis_port, redis_password)
-    thr.helpers.configure(config, redis, metrics)
+    checkoutlock = Mutex.new
+    thr.helpers.configure(config, redis, metrics, checkoutlock)
     thr.helpers.execute!
   end
   torun_threads << api

--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -36,10 +36,11 @@ module Vmpooler
     use Vmpooler::API::Reroute
     use Vmpooler::API::V1
 
-    def configure(config, redis, metrics)
+    def configure(config, redis, metrics, checkoutlock)
       self.settings.set :config, config
       self.settings.set :redis, redis
       self.settings.set :metrics, metrics
+      self.settings.set :checkoutlock, checkoutlock
     end
 
     def execute!

--- a/spec/integration/api/v1/vm_spec.rb
+++ b/spec/integration/api/v1/vm_spec.rb
@@ -29,12 +29,14 @@ describe Vmpooler::API::V1 do
     }
     let(:current_time) { Time.now }
     let(:vmname) { 'abcdefghijkl' }
+    let(:checkoutlock) { Mutex.new }
 
     before(:each) do
       app.settings.set :config, config
       app.settings.set :redis, redis
       app.settings.set :metrics, metrics
       app.settings.set :config, auth: false
+      app.settings.set :checkoutlock, checkoutlock
       create_token('abcdefghijklmnopqrstuvwxyz012345', 'jdoe', current_time)
     end
 

--- a/spec/integration/api/v1/vm_template_spec.rb
+++ b/spec/integration/api/v1/vm_template_spec.rb
@@ -29,12 +29,14 @@ describe Vmpooler::API::V1 do
 
     let(:current_time) { Time.now }
     let(:socket) { double('socket') }
+    let(:checkoutlock) { Mutex.new }
 
     before(:each) do
       app.settings.set :config, config
       app.settings.set :redis, redis
       app.settings.set :metrics, metrics
       app.settings.set :config, auth: false
+      app.settings.set :checkoutlock, checkoutlock
       create_token('abcdefghijklmnopqrstuvwxyz012345', 'jdoe', current_time)
     end
 


### PR DESCRIPTION
This commit adds a shared mutex to vmpooler API so that checkout requests can be synchronized across threads. Without this change it is possible in some scenarios for vmpooler to allocate the same SUT to different API requests for a VM.