### PR TITLE
Simplify declaration of checkoutlock mutex

### DIFF
--- a/bin/vmpooler
+++ b/bin/vmpooler
@@ -24,8 +24,7 @@ if torun.include? 'api'
   api = Thread.new do
     thr = Vmpooler::API.new
     redis = Vmpooler.new_redis(redis_host, redis_port, redis_password)
-    checkoutlock = Mutex.new
-    thr.helpers.configure(config, redis, metrics, checkoutlock)
+    thr.helpers.configure(config, redis, metrics)
     thr.helpers.execute!
   end
   torun_threads << api

--- a/lib/vmpooler/api.rb
+++ b/lib/vmpooler/api.rb
@@ -36,11 +36,11 @@ module Vmpooler
     use Vmpooler::API::Reroute
     use Vmpooler::API::V1
 
-    def configure(config, redis, metrics, checkoutlock)
+    def configure(config, redis, metrics)
       self.settings.set :config, config
       self.settings.set :redis, redis
       self.settings.set :metrics, metrics
-      self.settings.set :checkoutlock, checkoutlock
+      self.settings.set :checkoutlock, Mutex.new
     end
 
     def execute!


### PR DESCRIPTION
This commit updates the way that checkoutlock is defined so it is not passed through bin/vmpooler. Without this change there's an unnecessary layer the mutex passes through.