### PR TITLE
(QENG-7530) Make VM names more human readable

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'net-ldap', '~> 0.16'
 gem 'statsd-ruby', '~> 1.4.0', :require => 'statsd'
 gem 'connection_pool', '~> 2.2'
 gem 'nokogiri', '~> 1.8'
+gem 'spicy-proton', '2.1.1'
 
 group :development do
   gem 'pry'

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -1,4 +1,5 @@
 require 'vmpooler/providers'
+require 'spicy-proton'
 
 module Vmpooler
   class PoolManager
@@ -28,6 +29,9 @@ module Vmpooler
       @reconfigure_pool = {}
 
       @vm_mutex = {}
+
+      # Name generator for generating host names
+      @name_generator = Spicy::Proton.new
 
       # load specified providers from config file
       load_used_providers
@@ -265,8 +269,8 @@ module Vmpooler
 
     def _clone_vm(pool_name, provider)
       # Generate a randomized hostname
-      o = [('a'..'z'), ('0'..'9')].map(&:to_a).flatten
-      new_vmname = $config[:config]['prefix'] + o[rand(25)] + (0...14).map { o[rand(o.length)] }.join
+      random_name = [@name_generator.adjective(max: 7), @name_generator.noun(max: 7)].join('-')
+      new_vmname = $config[:config]['prefix'] + random_name
 
       # Add VM to Redis inventory ('pending' pool)
       $redis.sadd('vmpooler__pending__' + pool_name, new_vmname)


### PR DESCRIPTION
Prior to this commit hostnames for VMs provisioned by vmpooler were 15
random characters. This is difficult for humans to tell apart.

This commit updates the naming to use the `spicy-proton` gem to generate
adjective noun pair names for the VMs, which I think would be easier for
humans to tell apart, as well as fun and memorable to say.