### PR TITLE
Add spicy-proton to vmpooler.gemspec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'net-ldap', '~> 0.16'
 gem 'statsd-ruby', '~> 1.4.0', :require => 'statsd'
 gem 'connection_pool', '~> 2.2'
 gem 'nokogiri', '~> 1.8'
-gem 'spicy-proton', '2.1.1'
+gem 'spicy-proton', '~> 2.1'
 
 group :development do
   gem 'pry'

--- a/vmpooler.gemspec
+++ b/vmpooler.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_dependency 'statsd-ruby', '~> 1.4'
   s.add_dependency 'connection_pool', '~> 2.2'
   s.add_dependency 'nokogiri', '~> 1.8'
+  s.add_dependency 'spicy-proton', '~> 2.1'
 end


### PR DESCRIPTION
This commit adds the spicy-proton gem to vmpooler.gemspec. Without this change the spicy-proton gem is in the Gemfile, but not the gemspec, causing issues when deploying from gem.