### PR TITLE
(QENG-7530) Fix hostname_shorten regex

### DIFF
--- a/lib/vmpooler/api/helpers.rb
+++ b/lib/vmpooler/api/helpers.rb
@@ -140,7 +140,7 @@ module Vmpooler
       end
 
       def hostname_shorten(hostname, domain=nil)
-        if domain && hostname =~ /^\w+\.#{domain}$/
+        if domain && hostname =~ /^[\w-]+\.#{domain}$/
           hostname = hostname[/[^\.]+/]
         end
 

--- a/spec/unit/api/helpers_spec.rb
+++ b/spec/unit/api/helpers_spec.rb
@@ -19,6 +19,8 @@ describe Vmpooler::API::Helpers do
         ['example.com', 'not-example.com', 'example.com'],
         ['example.com', 'example.com', 'example.com'],
         ['sub.example.com', 'example.com', 'sub'],
+        ['adjective-noun.example.com', 'example.com', 'adjective-noun'],
+        ['abc123.example.com', 'example.com', 'abc123'],
         ['example.com', nil, 'example.com']
     ].each do |hostname, domain, expected|
       it { expect(subject.hostname_shorten(hostname, domain)).to eq expected }


### PR DESCRIPTION
Prior to this commit the hostname_shorten regex wouldn't match the
updated human readable hostnames because they contain dashes.
This commit updates the regex to capture dashes in the hostname.