### PR TITLE
(QENG-7530) Add check for unique hostnames

### DIFF
--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -608,6 +608,7 @@ EOT
         expect(metrics).to receive(:timing).with(/clone\./,/0/)
         expect(provider).to receive(:create_vm).with(pool, String)
         allow(logger).to receive(:log)
+        expect(subject).to receive(:find_unique_hostname).with(pool).and_return(vm)
       end
 
       it 'should create a cloning VM' do
@@ -649,6 +650,7 @@ EOT
       before(:each) do
         expect(provider).to receive(:create_vm).with(pool, String).and_raise('MockError')
         allow(logger).to receive(:log)
+        expect(subject).to receive(:find_unique_hostname).with(pool).and_return(vm)
       end
 
       it 'should not create a cloning VM' do


### PR DESCRIPTION
Prior to this commit the pooler had no awareness of the complete set of
hostnames that are currently in use. This meant that it was possible to
allocate the same hostname twice, which would result in the original
host with that hostname becoming unreachable.

This commit adds a check for the existence of the
`vmpooler__vm__<hostname>` key before attempting to  clone the vm.
This should prevent duplicate hostnames.

If the hostname is already taken, `_clone_vm` will retry with a new
random hostname multiple times before raising an exception.