### PR TITLE
(POOLER-154) Delay vm host update until after migration completes

### DIFF
--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -979,10 +979,10 @@ module Vmpooler
         def migrate_vm_to_new_host(pool_name, vm_name, vm_hash, connection)
           $redis.sadd('vmpooler__migration', vm_name)
           target_host_name = select_next_host(pool_name, @provider_hosts, vm_hash['architecture'])
-          $redis.hset("vmpooler__vm__#{vm_name}", 'host', target_host_name)
-          $redis.hset("vmpooler__vm__#{vm_name}", 'migrated', true)
           target_host_object = find_host_by_dnsname(connection, target_host_name)
           finish = migrate_vm_and_record_timing(pool_name, vm_name, vm_hash, target_host_object, target_host_name)
+          $redis.hset("vmpooler__vm__#{vm_name}", 'host', target_host_name)
+          $redis.hset("vmpooler__vm__#{vm_name}", 'migrated', true)
           logger.log('s', "[>] [#{pool_name}] '#{vm_name}' migrated from #{vm_hash['host_name']} to #{target_host_name} in #{finish} seconds")
         ensure
           $redis.srem('vmpooler__migration', vm_name)


### PR DESCRIPTION
Prior to this commit the vsphere migration code updated the redis value
for where the VM is running (`vmpooler__vm__#{vm_name}/host`) before
attempting the migration. This meant that if the migration failed, there
was no record of what the original host for the VM was. Additionally,
the VM was marked as migrated before the migration happened which
didn't reflect reality if the migration failed.

This commit moves the redis update during migration to after the
migration has completed. This means that if an exception is thrown in
the migration code, the original host won't be lost and the host won't
be considered as migrated when it was not.