### PR TITLE
(POOLER-157) Add extra_config option to vmpooler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,19 +13,19 @@ git logs & PR history.
 
 ## [Unreleased](https://github.com/puppetlabs/vmpooler/compare/0.10.3...master)
 
+### Added
+
+- Option to provide path to additional configuration files (POOLER-157)
+
 ## [0.10.3](https://github.com/puppetlabs/vmpooler/compare/0.10.2...0.10.3)
 
 - Fix Redis update during migration to better reflect actual state (POOLER-154)
 - Update Rubocop config, now we can actually see all the failing cops
 
 ## [0.10.2](https://github.com/puppetlabs/vmpooler/compare/0.10.1...0.10.2)
-- Version bump (no code changes)
 
-## [0.10.1](https://github.com/puppetlabs/vmpooler/compare/0.10.0...0.10.1)
 
-- No changes, version bump only
-
-## [0.10.0](https://github.com/puppetlabs/vmpooler/compare/0.9.1...0.10.0)
+## [0.10.2](https://github.com/puppetlabs/vmpooler/compare/0.9.1...0.10.2)
 
 ### Added
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,6 +176,13 @@ https://jenkins.example.com/job/platform\_puppet-agent-extra\_puppet-agent-integ
 Expects a boolean value
 (optional; default: false)
 
+### EXTRA\_CONFIG
+
+Specify additional application configuration files
+The argument can accept a full path to a file, or multiple files comma separated.
+Expects a string value
+(optional)
+
 ## API options <a name="API"></a>
 
 ### AUTH\_PROVIDER

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -27,6 +27,14 @@ module Vmpooler
       # Take the name of the config file either from an ENV variable or from the filepath argument
       config_file = ENV['VMPOOLER_CONFIG_FILE'] || filepath
       parsed_config = YAML.load_file(config_file) if File.exist? config_file
+      parsed_config[:config]['extra_config'] = ENV['EXTRA_CONFIG'] if ENV['EXTRA_CONFIG']
+      if parsed_config[:config]['extra_config']
+        extra_configs = parsed_config[:config]['extra_config'].split(',')
+        extra_configs.each do |config|
+          extra_config = YAML.load_file(config)
+          parsed_config.merge!(extra_config)
+        end
+      end
     end
 
     parsed_config ||= { config: {} }

--- a/spec/unit/env_config.rb
+++ b/spec/unit/env_config.rb
@@ -30,6 +30,7 @@ describe 'Vmpooler' do
         ['experimental_features', test_bool, nil],
         ['purge_unconfigured_folders', test_bool, nil],
         ['usage_stats', test_bool, nil],
+        ['extra_config', test_string, nil],
       ]
 
       test_cases.each do |key, value, default|

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -504,6 +504,12 @@
 #     lifetime (by checking how long it has already been running).
 #     (optional; default: unlimited)
 #
+#   - extra_config
+#     Specify additional application configuration files
+#     The argument can accept a full path to a file, or multiple files comma separated.
+#     Expects a string value
+#     (optional)
+#
 # Example:
 
 :config:


### PR DESCRIPTION
This commit adds the extra_config option to vmpooler to allow specifying additional configuration files to load from. Without this change vmpooler does not offer a mechanism to provide additional configuration files for the application.