### PR TITLE
Pin to JRuby 9.2.9 in Dockerfiles

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,7 @@
 # RUN:
 #   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 
-FROM jruby:9.2-jdk
+FROM jruby:9.2.9-jdk
 
 ARG vmpooler_version=0.5.0
 

--- a/docker/Dockerfile-aio
+++ b/docker/Dockerfile-aio
@@ -8,7 +8,7 @@
 # RUN:
 #   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 
-FROM jruby:9.2-jdk
+FROM jruby:9.2.9-jdk
 
 RUN mkdir -p /var/lib/vmpooler
 

--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -8,7 +8,7 @@
 # RUN:
 #   docker run -e VMPOOLER_CONFIG -p 80:4567 -it vmpooler
 
-FROM jruby:9.2-jdk
+FROM jruby:9.2.9-jdk
 
 COPY docker/docker-entrypoint.sh /usr/local/bin/
 COPY ./ ./


### PR DESCRIPTION
This commit pins all the `Dockerfile` to Jruby 9.2.9. This is an
attempt to narrow down if the JRuby 9.2.11 is the reason for the
StackOverflow we were seeing or if there is something strange going on
with an update to the Gemfiles.