### PR TITLE
(POOLER-156) Detect redis connection failures

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,9 @@ services:
       - type: bind
         source: ${PWD}/vmpooler.yaml
         target: /etc/vmpooler/vmpooler.yaml
+      - type: bind
+        source: ${PWD}/providers.yaml
+        target: /etc/vmpooler/providers.yaml
     ports:
       - "4567:4567"
     networks:
@@ -17,6 +20,9 @@ services:
       - VMPOOLER_DEBUG=true # for use of dummy auth
       - VMPOOLER_CONFIG_FILE=/etc/vmpooler/vmpooler.yaml
       - REDIS_SERVER=redislocal
+      - EXTRA_CONFIG=/etc/vmpooler/providers.yaml
+      - LOGFILE=/dev/stdout
+      - LDAP_PORT=636
     image: vmpooler-local
     depends_on:
       - redislocal

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -822,7 +822,7 @@ module Vmpooler
               loop_count += 1
             end
           end
-        rescue Redis::CannotConnectError => e
+        rescue Redis::CannotConnectError
           raise
         rescue StandardError => e
           $logger.log('s', "[!] [#{pool['name']}] Error while checking the pool: #{e}")

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -822,6 +822,8 @@ module Vmpooler
               loop_count += 1
             end
           end
+        rescue Redis::CannotConnectError => e
+          raise
         rescue StandardError => e
           $logger.log('s', "[!] [#{pool['name']}] Error while checking the pool: #{e}")
           raise
@@ -1310,6 +1312,9 @@ module Vmpooler
           loop_count += 1
         end
       end
+    rescue Redis::CannotConnectError => e
+      $logger.log('s', "Cannot connect to the redis server: #{e}")
+      raise
     end
   end
 end


### PR DESCRIPTION
This commit adds detection for redis connection failures to pool_manager. When a connection fails the error will be raised to executeforcing the connection to be re-established. Without this change, when a redis connection fails, it generates a redis connection error, which is swallowed by a rescue for StandardError, preventing the manager application component from recovering in the case of a redis connection failure.