### PR TITLE
(POOLER-165) Fix purge_unconfigured_folders

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -446,7 +446,7 @@ module Vmpooler
             begin
               purge_vms_and_folders(provider.to_s)
             rescue StandardError => e
-              $logger.log('s', "[!] failed while purging provider #{provider.to_s} VMs and folders with an error: #{e}")
+              $logger.log('s', "[!] failed while purging provider #{provider} VMs and folders with an error: #{e}")
             end
           end
         end

--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -444,9 +444,9 @@ module Vmpooler
         if provider_purge
           Thread.new do
             begin
-              purge_vms_and_folders($providers[provider.to_s])
+              purge_vms_and_folders(provider.to_s)
             rescue StandardError => e
-              $logger.log('s', "[!] failed while purging provider #{provider} VMs and folders with an error: #{e}")
+              $logger.log('s', "[!] failed while purging provider #{provider.to_s} VMs and folders with an error: #{e}")
             end
           end
         end
@@ -455,14 +455,13 @@ module Vmpooler
     end
 
     # Return a list of pool folders
-    def pool_folders(provider)
-      provider_name = provider.name
+    def pool_folders(provider_name)
       folders = {}
       $config[:pools].each do |pool|
         next unless pool['provider'] == provider_name
 
         folder_parts = pool['folder'].split('/')
-        datacenter = provider.get_target_datacenter_from_config(pool['name'])
+        datacenter = $providers[provider_name].get_target_datacenter_from_config(pool['name'])
         folders[folder_parts.pop] = "#{datacenter}/vm/#{folder_parts.join('/')}"
       end
       folders
@@ -479,8 +478,8 @@ module Vmpooler
     def purge_vms_and_folders(provider)
       configured_folders = pool_folders(provider)
       base_folders = get_base_folders(configured_folders)
-      whitelist = provider.provider_config['folder_whitelist']
-      provider.purge_unconfigured_folders(base_folders, configured_folders, whitelist)
+      whitelist = $providers[provider].provider_config['folder_whitelist']
+      $providers[provider].purge_unconfigured_folders(base_folders, configured_folders, whitelist)
     end
 
     def create_vm_disk(pool_name, vm, disk_size, provider)

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -118,10 +118,12 @@ module Vmpooler
 
             base_folders.each do |base_folder|
               folder_children = get_folder_children(base_folder, connection)
-              unless folder_children.empty?
-                folder_children.each do |folder_hash|
-                  folder_hash.each do |folder_title, folder_object|
-                    destroy_folder_and_children(folder_object) unless folder_configured?(folder_title, base_folder, configured_folders, whitelist)
+              next if folder_children.empty?
+
+              folder_children.each do |folder_hash|
+                folder_hash.each do |folder_title, folder_object|
+                  unless folder_configured?(folder_title, base_folder, configured_folders, whitelist)
+                    destroy_folder_and_children(folder_object)
                   end
                 end
               end

--- a/lib/vmpooler/providers/vsphere.rb
+++ b/lib/vmpooler/providers/vsphere.rb
@@ -122,9 +122,7 @@ module Vmpooler
 
               folder_children.each do |folder_hash|
                 folder_hash.each do |folder_title, folder_object|
-                  unless folder_configured?(folder_title, base_folder, configured_folders, whitelist)
-                    destroy_folder_and_children(folder_object)
-                  end
+                  destroy_folder_and_children(folder_object) unless folder_configured?(folder_title, base_folder, configured_folders, whitelist)
                 end
               end
             end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -1096,15 +1096,15 @@ EOT
     }
 
     it 'should return a list of pool folders' do
-      expect(provider).to receive(:get_target_datacenter_from_config).with(pool).and_return(datacenter)
+      expect($providers[provider_name]).to receive(:get_target_datacenter_from_config).with(pool).and_return(datacenter)
 
-      expect(subject.pool_folders(provider)).to eq(expected_response)
+      expect(subject.pool_folders(provider_name)).to eq(expected_response)
     end
 
     it 'should raise an error when the provider fails to get the datacenter' do
-      expect(provider).to receive(:get_target_datacenter_from_config).with(pool).and_raise('mockerror')
+      expect($providers[provider_name]).to receive(:get_target_datacenter_from_config).with(pool).and_raise('mockerror')
 
-      expect{ subject.pool_folders(provider) }.to raise_error(RuntimeError, 'mockerror')
+      expect{ subject.pool_folders(provider_name) }.to raise_error(RuntimeError, 'mockerror')
     end
   end
 
@@ -1135,14 +1135,16 @@ EOT
 
     it 'should run purge_unconfigured_folders' do
       expect(subject).to receive(:pool_folders).and_return(configured_folders)
-      expect(provider).to receive(:purge_unconfigured_folders).with(base_folders, configured_folders, whitelist)
+      expect($providers[provider_name]).to receive(:purge_unconfigured_folders).with(base_folders, configured_folders, whitelist)
+      expect($providers[provider_name]).to receive(:provider_config).and_return({})
 
       subject.purge_vms_and_folders(provider)
     end
 
     it 'should raise any errors' do
       expect(subject).to receive(:pool_folders).and_return(configured_folders)
-      expect(provider).to receive(:purge_unconfigured_folders).with(base_folders, configured_folders, whitelist).and_raise('mockerror')
+      expect($providers[provider_name]).to receive(:purge_unconfigured_folders).with(base_folders, configured_folders, whitelist).and_raise('mockerror')
+      expect($providers[provider_name]).to receive(:provider_config).and_return({})
 
       expect{ subject.purge_vms_and_folders(provider) }.to raise_error(RuntimeError, 'mockerror')
     end


### PR DESCRIPTION
This commit fixes the purge_unconfigured_folders feature to ensure that it can successfully identify folders and instances that are no longer used. Without this change the feature does not work as advertised.