### PR TITLE
(POOLER-161) Fix extending vm lifetime when max lifetime is set

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -909,13 +909,6 @@ module Vmpooler
                 max_lifetime_upper_limit = max_lifetime_upper_limit.to_i
                 if arg.to_i >= max_lifetime_upper_limit
                   failure.push("You provided a lifetime (#{arg}) that exceeds the configured maximum of #{max_lifetime_upper_limit}.")
-                else
-                  # also make sure we do not extend past max_lifetime_upper_limit
-                  rdata = backend.hgetall('vmpooler__vm__' + params[:hostname])
-                  running = ((Time.now - Time.parse(rdata['checkout'])) / 60 / 60).round(2)
-                  unless running + arg.to_i < max_lifetime_upper_limit
-                    failure.push("You provided a lifetime (#{arg}) that will extend the current lifetime past the configured maximum of #{max_lifetime_upper_limit}.")
-                  end
                 end
               end
 

--- a/spec/integration/api/v1/vm_hostname_spec.rb
+++ b/spec/integration/api/v1/vm_hostname_spec.rb
@@ -134,7 +134,7 @@ describe Vmpooler::API::V1 do
           expect(vm['lifetime']).to eq("20000")
         end
 
-        it 'does not allow a lifetime to be initially past config 168' do
+        it 'does not allow a lifetime to be initially past config max_lifetime_upper_limit' do
           app.settings.set :config,
                            { :config => { 'max_lifetime_upper_limit' => 168 } }
           create_vm('testhost')
@@ -146,18 +146,6 @@ describe Vmpooler::API::V1 do
           expect(vm['lifetime']).to be_nil
         end
 
-        it 'does not allow a lifetime to be extended past config 168' do
-          app.settings.set :config,
-                           { :config => { 'max_lifetime_upper_limit' => 168 } }
-          create_vm('testhost')
-
-          set_vm_data('testhost', "checkout", (Time.now - (69*60*60)))
-          put "#{prefix}/vm/testhost", '{"lifetime":"100"}'
-          expect_json(ok = false, http = 400)
-
-          vm = fetch_vm('testhost')
-          expect(vm['lifetime']).to be_nil
-        end
       end
 
       context '(auth configured)' do


### PR DESCRIPTION
Before this PR, the current running time was being inspected to decide if the
vm lifetime could be extended. But since vm lifetime is absolute and not relative
this check is now removed.