### PR TITLE
Rescue and warn when graphite connection cannot be opened

### DIFF
--- a/lib/vmpooler/graphite.rb
+++ b/lib/vmpooler/graphite.rb
@@ -35,6 +35,8 @@ module Vmpooler
           socket.close
         end
       end
+    rescue Errno::EADDRNOTAVAIL => e
+      warn "Could not assign address to graphite server #{server}: #{e}"
     rescue StandardError => e
       warn "Failure logging #{path} to graphite server [#{server}:#{port}]: #{e}"
     end


### PR DESCRIPTION
This commit updates vmpooler graphite stats behavior when a connection cannot be opened to the graphite server to warn instead of allowing the full backtrace to be output to stderr. Without this change a backtrace is output to stderr when a graphite connection fails.