### PR TITLE
(POOLER-181) Separate Dashboard from api

### DIFF
--- a/bin/vmpooler
+++ b/bin/vmpooler
@@ -16,20 +16,21 @@ metrics = Vmpooler::Metrics.init(logger, config)
 
 torun_threads = []
 if ARGV.count == 0
-  torun = %i[api manager]
+  torun = %i[api manager dashboard]
 else
   torun = []
   torun << :api if ARGV.include? 'api'
   torun << :manager if ARGV.include? 'manager'
+  torun << :dashboard if ARGV.include? 'dashboard'
   exit(2) if torun.empty?
 end
 
-if torun.include? :api
-  api = Thread.new do
+if (torun & %i[api dashboard]).any?
+  api_or_dashboard = Thread.new do
     redis = Vmpooler.new_redis(redis_host, redis_port, redis_password)
     Vmpooler::API.execute(torun, config, redis, metrics, logger)
   end
-  torun_threads << api
+  torun_threads << api_or_dashboard
 elsif metrics.respond_to?(:setup_prometheus_metrics)
   # Run the cut down API - Prometheus Metrics only.
   prometheus_only_api = Thread.new do

--- a/spec/integration/dashboard_spec.rb
+++ b/spec/integration/dashboard_spec.rb
@@ -27,7 +27,7 @@ describe Vmpooler::API do
 
     before(:each) do
       expect(app).to receive(:run!)
-      app.execute([:api], config, redis, nil, nil)
+      app.execute([:dashboard], config, redis, nil, nil)
       app.settings.set :config, auth: false
     end
 


### PR DESCRIPTION
Allow the dashboard to run separately from the API, so that the
dashboard can be scaled appropriately.

Note - this implementation actually co-runs the api in the dashboard
instance to re-use the api code for the dashboard endpoints and other
v1 endpoints collecting the operating information.