### PR TITLE
Test vmpooler on latest 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,16 +5,13 @@ os: linux
 
 jobs:
   include:
-    - rvm: 2.4.9
+    - rvm: 2.5.8
       env: "CHECK=rubocop"
 
-    - rvm: 2.4.9
+    - rvm: 2.5.8
       env: "CHECK=test"
 
-    - rvm: 2.5.7
-      env: "CHECK=test"
-
-    - rvm: jruby-9.2.9.0
+    - rvm: jruby-9.2.12.0
       env: "CHECK=test"
 
 script:


### PR DESCRIPTION
This change updates vmpooler to test ruby 2.5.8, and jruby 9.2.12.0. Without this change vmpooler tests against 2.5.7 and jruby 9.2.9.0. Additionally, testing on 2.4.x is removed. Lastly, rubocop tests are updated to run on 2.5.8.