### PR TITLE
(POOLER-186) Fix template alias evaluation with backend weight of 0

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -89,17 +89,15 @@ module Vmpooler
         template_backends += aliases
         weighted_pools = get_pool_weights(template_backends)
 
-        pickup = Pickup.new(weighted_pools) if weighted_pools.count == template_backends.count
-        count.to_i.times do
-          if pickup
+        if weighted_pools.count > 1 && weighted_pools.count == template_backends.count
+          pickup = Pickup.new(weighted_pools)
+          count.to_i.times do
             selection << pickup.pick
-          else
+          end
+        else
+          count.to_i.times do
             selection << template_backends.sample
           end
-        end
-      else
-        count.to_i.times do
-          selection << template
         end
       end
 


### PR DESCRIPTION
This change fixes template alias evaluation to ensure that the correct
data is set when generating on demand requests for pools that have a
backend weight configured for a value of 0. Without this change vmpooler
will return an empty selection in api for template alias evaluation.

To support this change tests are added that first reproduced the
failure, and then verified that it is resolved with the addition of the
patch. Additionally, test coverage is added to ensure that code paths
that include pickup gem usage are covered.