### PR TITLE
Bump OTel Sinatra to 0.7.1

### DIFF
--- a/vmpooler.gemspec
+++ b/vmpooler.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'opentelemetry-exporter-jaeger', '~> 0.7.0'
   s.add_dependency 'opentelemetry-instrumentation-concurrent_ruby', '~> 0.7.0'
   s.add_dependency 'opentelemetry-instrumentation-redis', '~> 0.7.0'
-  s.add_dependency 'opentelemetry-instrumentation-sinatra', '~> 0.7.0'
+  s.add_dependency 'opentelemetry-instrumentation-sinatra', '~> 0.7.1'
   s.add_dependency 'opentelemetry-resource_detectors', '~> 0.7.0'
   s.add_dependency 'opentelemetry-sdk', '~> 0.7.0'
   s.add_dependency 'pickup', '~> 0.0.11'


### PR DESCRIPTION
This is to pull in the bug fix in https://github.com/open-telemetry/opentelemetry-ruby/pull/434 so that the new feature of naming spans based on their Sinatra route actually works.