### PR TITLE
(POOLER-191) Add checking for running instances that are not in active

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -289,19 +289,15 @@ module Vmpooler
                 move_vm_queue(pool, vm, 'running', 'completed', redis, "reached end of TTL after #{ttl} hours")
                 throw :stop_checking
               end
-            end
-
-            if provider.vm_ready?(pool, vm)
-              throw :stop_checking
             else
-              host = provider.get_vm(pool, vm)
-
-              if host
-                throw :stop_checking
-              else
-                move_vm_queue(pool, vm, 'running', 'completed', redis, 'is no longer in inventory, removing from running')
-              end
+              move_vm_queue(pool, vm, 'running', 'completed', redis, 'is listed as running, but has no checkouttime data. Removing from running')
             end
+
+            throw :stop_checking if provider.vm_ready?(pool, vm)
+
+            throw :stop_checking if provider.get_vm(pool, vm)
+
+            move_vm_queue(pool, vm, 'running', 'completed', redis, 'is no longer in inventory, removing from running')
           end
         end
       end

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -647,12 +647,20 @@ EOT
     end
 
     context 'valid host' do
-      it 'should not move VM if it has no checkout time' do
+      it 'should kill a VM if it has no checkout time' do
         redis_connection_pool.with do |redis|
           expect(provider).to receive(:vm_ready?).and_return(true)
           expect(redis.sismember("vmpooler__running__#{pool}", vm)).to be(true)
           subject._check_running_vm(vm, pool, 0, provider)
-          expect(redis.sismember("vmpooler__running__#{pool}", vm)).to be(true)
+          expect(redis.sismember("vmpooler__running__#{pool}", vm)).to be(false)
+        end
+      end
+
+      it 'should log a message when the machine is removed due to no active data' do
+        redis_connection_pool.with do |redis|
+          expect(provider).to receive(:vm_ready?).and_return(true)
+          expect(logger).to receive(:log).with('d',"[!] [#{pool}] '#{vm}' is listed as running, but has no checkouttime data. Removing from running")
+          subject._check_running_vm(vm, pool, 0, provider)
         end
       end
 


### PR DESCRIPTION
This change adds detection of running instances that are in a running
queue, but have no data in a active queue for the same pool. When this
happens a machine will live forever, impacting the running count, and
preventing the machine from being killed. Without this change running
instances that are not marked as active will live forever.