### PR TITLE
(maint) Speedup the tagging method

### DIFF
--- a/lib/vmpooler/api/helpers.rb
+++ b/lib/vmpooler/api/helpers.rb
@@ -114,11 +114,13 @@ module Vmpooler
       end
 
       def export_tags(backend, hostname, tags)
-        tags.each_pair do |tag, value|
-          next if value.nil? or value.empty?
+        backend.pipelined do
+          tags.each_pair do |tag, value|
+            next if value.nil? or value.empty?
 
-          backend.hset('vmpooler__vm__' + hostname, 'tag:' + tag, value)
-          backend.hset('vmpooler__tag__' + Date.today.to_s, hostname + ':' + tag, value)
+            backend.hset('vmpooler__vm__' + hostname, 'tag:' + tag, value)
+            backend.hset('vmpooler__tag__' + Date.today.to_s, hostname + ':' + tag, value)
+          end
         end
       end
 

--- a/vmpooler.gemspec
+++ b/vmpooler.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rack-test', '>= 0.6'
   s.add_development_dependency 'rspec', '>= 3.2'
-  s.add_development_dependency 'rubocop'
+  s.add_development_dependency 'rubocop', '< 1.0'
   s.add_development_dependency 'simplecov', '>= 0.11.2'
   s.add_development_dependency 'yarjuf', '>= 2.0'
 end


### PR DESCRIPTION
While looking at the instrumentation data for the ABS queue processor,
I noticed a lot of time spent in the HTTP PUT method, which in the code
was easy to isolate, as it is only used via the vmpooler tagging functions
ie the API /vm/foobar/ with 'tag' key-value pairs.
While I'm not sure the original hset() make sense to me, there was an easy
way to speed them up by using pipelined. I would expect a very good speed
increase with this turned on.