### PR TITLE
(MAINT) Fix checkout counter allocation

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -209,7 +209,7 @@ module Vmpooler
             break
           else
             vms << [vmpool, vmname, vmtemplate]
-            metrics.increment("checkout.success.#{vmtemplate}")
+            metrics.increment("checkout.success.#{vmpool}")
           end
         end
       end


### PR DESCRIPTION
Checkout metric counters were against the template name and not the
actual pool used which prevents us from counting the checkouts in the
pixa4 pools for example.