### PR TITLE
(MAINT) Fix checkout counter allocation

### DIFF
--- a/lib/vmpooler/api/v1.rb
+++ b/lib/vmpooler/api/v1.rb
@@ -213,7 +213,7 @@ module Vmpooler
           if vmname
             account_for_starting_vm(vmpool, vmname)
             vms << [vmpool, vmname, vmtemplate]
-            metrics.increment("checkout.success.#{vmtemplate}")
+            metrics.increment("checkout.success.#{vmpool}")
           else
             failed = true
             metrics.increment("checkout.empty.#{requested}")


### PR DESCRIPTION
Checkout metric counters were against the template name and not the
actual pool used which prevents us from counting the checkouts in the
pixa4 pools for example.

Note - this is a re-rerun - the last commit on this file over-wrote
the change.