### PR TITLE
(DIO-1503) Fix regex for ondemand instances

### DIFF
--- a/lib/vmpooler/metrics/promstats/collector_middleware.rb
+++ b/lib/vmpooler/metrics/promstats/collector_middleware.rb
@@ -113,7 +113,7 @@ module Vmpooler
           # Similarly, request IDs are also stripped from the /ondemand path.
           path
             .gsub(%r{/vm/.+$}, '/vm')
-            .gsub(%r{/ondemand/.+$}, '/ondemand')
+            .gsub(%r{/ondemandvm/.+$}, '/ondemandvm')
             .gsub(%r{/token/.+$}, '/token')
             .gsub(%r{/lib/.+$}, '/lib')
             .gsub(%r{/img/.+$}, '/img')

--- a/spec/unit/collector_middleware_spec.rb
+++ b/spec/unit/collector_middleware_spec.rb
@@ -72,14 +72,14 @@ describe Vmpooler::Metrics::Promstats::CollectorMiddleware do
   it 'normalizes paths containing /ondemandvm by ' do
     expect(Benchmark).to receive(:realtime).and_yield.and_return(0.3)
 
-    get '/foo/ondemand/bar/fatman'
+    get '/foo/ondemandvm/bar/fatman'
 
     metric = :http_server_requests_total
-    labels = { method: 'get', path: '/foo/ondemand', code: '200' }
+    labels = { method: 'get', path: '/foo/ondemandvm', code: '200' }
     expect(registry.get(metric).get(labels: labels)).to eql(1.0)
 
     metric = :http_server_request_duration_seconds
-    labels = { method: 'get', path: '/foo/ondemand' }
+    labels = { method: 'get', path: '/foo/ondemandvm' }
     expect(registry.get(metric).get(labels: labels)).to include("0.1" => 0, "0.5" => 1)
   end
 


### PR DESCRIPTION
It appears we renamed `/ondemand/` to `/ondemandvm/` at some point and, as a result, have not been stripping hostnames from that endpoint's metrics. This has caused issues with metrics collection due a very high cardinality.