### PR TITLE
(DIO-2621) Make LDAP encryption configurable

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -119,6 +119,11 @@ module Vmpooler
       parsed_config[:auth][:ldap]['port']        = string_to_int(ENV['LDAP_PORT']) if ENV['LDAP_PORT']
       parsed_config[:auth][:ldap]['base']        = ENV['LDAP_BASE'] if ENV['LDAP_BASE']
       parsed_config[:auth][:ldap]['user_object'] = ENV['LDAP_USER_OBJECT'] if ENV['LDAP_USER_OBJECT']
+      if parsed_config[:auth]['provider'] == 'ldap' && parsed_config[:auth][:ldap].key?('encryption')
+        parsed_config[:auth][:ldap]['encryption'] = parsed_config[:auth][:ldap]['encryption']
+      elsif parsed_config[:auth]['provider'] == 'ldap'
+        parsed_config[:auth][:ldap]['encryption'] = {}
+      end
     end
 
     # Create an index of pool aliases

--- a/lib/vmpooler/api/helpers.rb
+++ b/lib/vmpooler/api/helpers.rb
@@ -56,14 +56,11 @@ module Vmpooler
         return false
       end
 
-      def authenticate_ldap(port, host, user_object, base, username_str, password_str)
+      def authenticate_ldap(port, host, encryption_hash, user_object, base, username_str, password_str)
         ldap = Net::LDAP.new(
           :host => host,
           :port => port,
-          :encryption => {
-            :method => :start_tls,
-            :tls_options => { :ssl_version => 'TLSv1' }
-          },
+          :encryption => encryption_hash,
           :base => base,
           :auth => {
             :method => :simple,
@@ -86,6 +83,10 @@ module Vmpooler
           ldap_port = auth[:ldap]['port'] || 389
           ldap_user_obj = auth[:ldap]['user_object']
           ldap_host = auth[:ldap]['host']
+          ldap_encryption_hash = auth[:ldap]['encryption'] || {
+            :method => :start_tls,
+            :tls_options => { :ssl_version => 'TLSv1' }
+          }
 
           unless ldap_base.is_a? Array
             ldap_base = ldap_base.split
@@ -100,6 +101,7 @@ module Vmpooler
               result = authenticate_ldap(
                 ldap_port,
                 ldap_host,
+                ldap_encryption_hash,
                 search_user_obj,
                 search_base,
                 username_str,

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -373,7 +373,11 @@
   provider: 'ldap'
   :ldap:
     host: 'ldap.example.com'
-    port: 389
+    port: 636
+    encryption:
+      :method: :simple_tls
+      :tls_options:
+        :ssl_version: 'TLSv1_2'
     base: 'ou=users,dc=company,dc=com'
     user_object: 'uid'
 


### PR DESCRIPTION
Prior to this, the encryption settings for LDAP auth were hard coded to start_tls on port 389 with TLSv1. These are still the defaults, as insecure as they are, so as to not break existing users. This change facilitates replacing the defaults so that simple_tls over port 636 via TLS1.2 can be used.