### PR TITLE
(DIO-2675) Undo pool size & template overrides

### DIFF
--- a/docker/Dockerfile_local
+++ b/docker/Dockerfile_local
@@ -10,9 +10,6 @@
 
 FROM jruby:9.2-jdk
 
-COPY docker/docker-entrypoint.sh /usr/local/bin/
-COPY ./ ./
-
 ENV RACK_ENV=production
 
 RUN apt-get update -qq && \
@@ -21,9 +18,18 @@ RUN apt-get update -qq && \
     apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
+COPY docker/docker-entrypoint.sh /usr/local/bin/
+COPY ./Gemfile ./
+COPY ./vmpooler.gemspec ./
+COPY ./lib/vmpooler/version.rb ./lib/vmpooler/version.rb
+
 RUN gem install bundler && \
-    bundle install && \
-    gem build vmpooler.gemspec && \
+    bundle config set --local jobs 3 && \
+    bundle install
+
+COPY ./ ./
+
+RUN gem build vmpooler.gemspec && \
     gem install vmpooler*.gem && \
     chmod +x /usr/local/bin/docker-entrypoint.sh
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -743,6 +743,28 @@ $ curl -X POST -H "Content-Type: application/json" -d '{"debian-7-i386":"2","deb
 }
 ```
 
+##### DELETE /config/poolsize/&lt;pool&gt;
+
+Delete an overridden pool size. This results in the values from VMPooler's config being used.
+
+Return codes:
+* 200 - when nothing was changed but no error occurred
+* 201 - size reset successful
+* 401 - when not authorized
+* 404 - pool does not exist
+* 405 - The endpoint is disabled because experimental features are disabled
+
+```
+$ curl -X DELETE -u jdoe --url vmpooler.example.com/api/v1/poolsize/almalinux-8-x86_64
+```
+```json
+{
+    "ok": true,
+    "pool_size_before_overrides": 2,
+    "pool_size_before_reset": 4
+}
+```
+
 ##### POST /config/pooltemplate
 
 Change the template configured for a pool, and replenish the pool with instances built from the new template.
@@ -772,6 +794,28 @@ $ curl -X POST -H "Content-Type: application/json" -d '{"debian-7-i386":"templat
 ```json
 {
   "ok": true
+}
+```
+
+##### DELETE /config/pooltemplate/&lt;pool&gt;
+
+Delete an overridden pool template. This results in the values from VMPooler's config being used.
+
+Return codes:
+* 200 - when nothing was changed but no error occurred
+* 201 - template reset successful
+* 401 - when not authorized
+* 404 - pool does not exist
+* 405 - The endpoint is disabled because experimental features are disabled
+
+```
+$ curl -X DELETE -u jdoe --url vmpooler.example.com/api/v1/pooltemplate/almalinux-8-x86_64
+```
+```json
+{
+    "ok": true,
+    "template_before_overrides": "templates/almalinux-8-x86_64-0.0.2",
+    "template_before_reset": "templates/almalinux-8-x86_64-0.0.3-beta"
 }
 ```
 

--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -133,8 +133,17 @@ module Vmpooler
       parsed_config[:pools] = load_pools_from_redis(redis)
     end
 
+    # Marshal.dump is paired with Marshal.load to create a copy that has its own memory space
+    # so that each can be edited independently
+    # rubocop:disable Security/MarshalLoad
+
+    # retain a copy of the pools that were observed at startup
+    serialized_pools = Marshal.dump(parsed_config[:pools])
+    parsed_config[:pools_at_startup] = Marshal.load(serialized_pools)
+
     # Create an index of pools by title
     parsed_config[:pool_index] = pool_index(parsed_config[:pools])
+    # rubocop:enable Security/MarshalLoad
 
     parsed_config[:pools].each do |pool|
       parsed_config[:pool_names] << pool['name']

--- a/spec/unit/vmpooler_spec.rb
+++ b/spec/unit/vmpooler_spec.rb
@@ -20,6 +20,21 @@ describe 'Vmpooler' do
           expect(Vmpooler.config[:pools]).to eq(default_config[:pools])
         end
       end
+
+      it 'keeps a copy of the original pools at startup' do
+        Dir.chdir(fixtures_dir) do
+          configuration = Vmpooler.config
+          expect(configuration[:pools]).to eq(configuration[:pools_at_startup])
+        end
+      end
+
+      it 'the copy is a separate object and not a reference' do
+        Dir.chdir(fixtures_dir) do
+          configuration = Vmpooler.config
+          configuration[:pools][0]['template'] = 'sam'
+          expect(configuration[:pools]).not_to eq(configuration[:pools_at_startup])
+        end
+      end
     end
 
     context 'when config variable is set' do


### PR DESCRIPTION
This implements a delete method for pooltemplate and poolsize. The API removes the override from Redis and then adds an entry in Redis that causes the pool manager to wake up and process the removal of the override.

To facilitate this, a new variable has been created in lib/vmpooler.rb to hold a copy of the original / pre-override config. This supplemental copy of the pools is then indexed for use as a reference.

When pool manager wakes up to process an override removal, it looks up the pre-override value from the config via the new variables mentioned above.

Just as with entering overrides, no restart is needed. Template and pool size changes are logged so that anyone watching or reviewing the logs can see what happened when. The new API endpoints also return values for both the pre-revert and post-revert value.

There is a second commit that also makes it so that Dockerfile_local can use cached layers when all that is changing is VMPooler's code, and not its gems.