### PR TITLE
(maint) Adding a provider method tag_vm_user

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -294,6 +294,12 @@ module Vmpooler
               move_vm_queue(pool, vm, 'running', 'completed', redis, 'is listed as running, but has no checkouttime data. Removing from running')
             end
 
+            # tag VM if not tagged yet, this ensures the method is only called once
+            unless redis.hget("vmpooler__vm__#{vm}", 'user_tagged')
+              success = provider.tag_vm_user(pool, vm)
+              redis.hset("vmpooler__vm__#{vm}", 'user_tagged', 'true') if success
+            end
+
             throw :stop_checking if provider.vm_ready?(pool, vm)
 
             throw :stop_checking if provider.get_vm(pool, vm)

--- a/lib/vmpooler/providers/base.rb
+++ b/lib/vmpooler/providers/base.rb
@@ -212,6 +212,22 @@ module Vmpooler
           raise("#{self.class.name} does not implement vm_ready?")
         end
 
+        # tag_vm_user This method is called once we know who is using the VM (it is running). This method enables seeing
+        # who is using what in the provider pools.
+        # This method should be implemented in the providers, if it is not implemented, this base method will be called
+        # and should be a noop. The implementation should check if the vm has a user (as per redis) and add a new tag
+        # with the information.
+        # inputs
+        #   [String] pool_name : Name of the pool
+        #   [String] vm_name   : Name of the VM to check if ready
+        # returns
+        #   [Boolean] : true if successful, false if an error occurred and it should retry
+        def tag_vm_user(_pool_name, _vm_name)
+          # noop by design. If the provider does not implement this method, this base method is called (because inherited)
+          # and should basically do nothing.
+          true
+        end
+
         # inputs
         #   [String] pool_name : Name of the pool
         #   [String] vm_name   : Name of the VM to check if it exists


### PR DESCRIPTION
This method should be called only once, when the VM is moved to a running state
which is when the data for the user (if using tokens) is available. In vmpooler
base provider it is a noop method, but the various providers can implement it
to tag or label a running VM with the name of the user who checked it out