### PR TITLE
Ensure all configured providers are loaded

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -619,8 +619,21 @@ module Vmpooler
     # @return [Array] - a list of used providers from the config file, defaults to the default providers
     # ie. ["dummy"]
     def used_providers
-      pools = config[:pools] || []
-      @used_providers ||= (pools.map { |pool| pool[:provider] || pool['provider'] }.compact + default_providers).uniq
+      # create an array of provider classes based on the config
+      if config[:providers]
+        config_provider_names = config[:providers].keys
+        config_providers = config_provider_names.map do |config_provider_name|
+          if config[:providers][config_provider_name] && config[:providers][config_provider_name]['provider_class']
+            config[:providers][config_provider_name]['provider_class'].to_s
+          else
+            config_provider_name.to_s
+          end
+        end.compact.uniq
+      else
+        config_providers = []
+      end
+      # return the unique array of providers from the config and VMPooler defaults
+      @used_providers ||= (config_providers + default_providers).uniq
     end
 
     # @return [Array] - returns a list of providers that should always be loaded

--- a/spec/unit/pool_manager_spec.rb
+++ b/spec/unit/pool_manager_spec.rb
@@ -75,6 +75,84 @@ EOT
     end
   end
 
+  describe '#used_providers' do
+    context 'with no named providers' do
+      let(:config) { YAML.load(<<-EOT
+---
+:config:
+:pools:
+  - name: '#{pool}'
+    size: 1
+    provider: 'spoof'
+    EOT
+      )
+      }
+      it do
+        result = ["dummy"]
+        expect(subject.used_providers).to eq(result)
+      end
+    end
+    context 'with one named provider without a provider_class key' do
+      let(:config) { YAML.load(<<-EOT
+---
+:config:
+:providers:
+  :mock:
+:pools:
+  - name: '#{pool}'
+    size: 1
+    provider: 'spoof'
+    EOT
+      )
+      }
+      it do
+        result = ["mock", "dummy"]
+        expect(subject.used_providers).to eq(result)
+      end
+    end
+
+    context 'with one named provider with a provider_class key' do
+      let(:config) { YAML.load(<<-EOT
+---
+:config:
+:providers:
+  :mock:
+    provider_class: 'mock_mock'
+:pools:
+  - name: '#{pool}'
+    size: 1
+    provider: 'spoof'
+    EOT
+      )
+      }
+      it do
+        result = ["mock_mock", "dummy"]
+        expect(subject.used_providers).to eq(result)
+      end
+    end
+
+    context 'with one named provider with a provider_class key and one without' do
+      let(:config) { YAML.load(<<-EOT
+---
+:config:
+:providers:
+  :mock:
+    provider_class: 'mock_mock'
+  :foo:
+:pools:
+  - name: '#{pool}'
+    size: 1
+    provider: 'spoof'
+    EOT
+      )
+      }
+      it do
+        result = ["mock_mock", "foo", "dummy"]
+        expect(subject.used_providers).to eq(result)
+      end
+    end
+  end
+
   it '#default_providers' do
     expect(subject.default_providers).to eq(['dummy'])
   end


### PR DESCRIPTION
Prior to this, providers that should have been loaded per the provider_class key of the providers hash were not actually loaded.