### PR TITLE
(maint) Fix EXTRA_CONFIG merge behavior

### DIFF
--- a/lib/vmpooler.rb
+++ b/lib/vmpooler.rb
@@ -3,6 +3,7 @@
 module Vmpooler
   require 'concurrent'
   require 'date'
+  require 'deep_merge'
   require 'json'
   require 'net/ldap'
   require 'open-uri'
@@ -42,7 +43,7 @@ module Vmpooler
         extra_configs = parsed_config[:config]['extra_config'].split(',')
         extra_configs.each do |config|
           extra_config = YAML.load_file(config)
-          parsed_config.merge!(extra_config)
+          parsed_config.deep_merge(extra_config)
         end
       end
     end

--- a/lib/vmpooler/providers/base.rb
+++ b/lib/vmpooler/providers/base.rb
@@ -242,7 +242,7 @@ module Vmpooler
         # returns
         #   nil when successful. Raises error when encountered
         def create_template_delta_disks(_pool)
-          raise("#{self.class.name} does not implement create_template_delta_disks")
+          puts("#{self.class.name} does not implement create_template_delta_disks")
         end
 
         # inputs

--- a/spec/fixtures/extra_config1.yaml
+++ b/spec/fixtures/extra_config1.yaml
@@ -1,0 +1,4 @@
+---
+:providers:
+  :alice:
+    foo: "foo"

--- a/spec/fixtures/extra_config2.yaml
+++ b/spec/fixtures/extra_config2.yaml
@@ -1,0 +1,11 @@
+---
+:providers:
+  :bob:
+    foo: "foo_bob"
+    bar: "bar"
+
+:pools:
+  - name: 'pool05'
+    size: 5
+    provider: dummy
+    ready_ttl: 5

--- a/spec/unit/vmpooler_spec.rb
+++ b/spec/unit/vmpooler_spec.rb
@@ -45,9 +45,29 @@ describe 'Vmpooler' do
     end
 
     context 'when config file is set' do
-      it 'should use the file' do
+      before(:each) do
         ENV['VMPOOLER_CONFIG_FILE'] = config_file
+      end
+      it 'should use the file' do
         expect(Vmpooler.config[:pools]).to eq(config[:pools])
+      end
+      it 'merges one extra file, results in two providers' do
+        ENV['EXTRA_CONFIG'] = File.join(fixtures_dir, 'extra_config1.yaml')
+        expect(Vmpooler.config[:providers].keys).to include(:dummy)
+        expect(Vmpooler.config[:providers].keys).to include(:alice)
+      end
+      it 'merges two extra file, results in three providers and an extra pool' do
+        extra1 = File.join(fixtures_dir, 'extra_config1.yaml')
+        extra2 = File.join(fixtures_dir, 'extra_config2.yaml')
+        ENV['EXTRA_CONFIG'] = "#{extra1},#{extra2}"
+        expect(Vmpooler.config[:providers].keys).to include(:dummy)
+        expect(Vmpooler.config[:providers].keys).to include(:alice)
+        expect(Vmpooler.config[:providers].keys).to include(:bob)
+        merged_pools = [{"name"=>"pool03", "provider"=>"dummy", "ready_ttl"=>5, "size"=>5},
+                        {"name"=>"pool04", "provider"=>"dummy", "ready_ttl"=>5, "size"=>5},
+                        {"name"=>"pool05", "provider"=>"dummy", "ready_ttl"=>5, "size"=>5}]
+        expect(Vmpooler.config[:pools]).to eq(merged_pools)
+        expect(Vmpooler.config[:config]).not_to be_nil #merge does not deleted existing keys
       end
     end
   end

--- a/vmpooler.gemspec
+++ b/vmpooler.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.add_dependency 'concurrent-ruby', '~> 1.1'
   s.add_dependency 'connection_pool', '~> 2.2'
+  s.add_dependency 'deep_merge', '~> 1.2'
   s.add_dependency 'net-ldap', '~> 0.16'
   s.add_dependency 'nokogiri', '~> 1.10'
   s.add_dependency 'opentelemetry-exporter-jaeger', '= 0.20.1'


### PR DESCRIPTION
Before this change if an extra config file had new keys they would get
merged to the main config but if it contained an existing key, like
'providers' it would overwrite the original config.
Adding a library 'deep_merge' to do a more natural merge, where existing keys
get sub-elements added together and arrays are combined like for the
pool configuration.
Adding spec tests around EXTRA_CONFIG as they were missing, by adding
and testing two new extra_config.yaml fixture files