### PR TITLE
Bump jruby to 9.4.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,10 @@ jobs:
           prerelease: false
 
       # This step should closely match what is used in `docker/Dockerfile` in vmpooler-deployment
-      - name: Install Ruby jruby-9.4.1.0
+      - name: Install Ruby jruby-9.4.2.0
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 'jruby-9.4.1.0'
+          ruby-version: 'jruby-9.4.2.0'
 
       - name: Build gem
         run: gem build *.gemspec

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 'jruby-9.4.1.0'
+          - 'jruby-9.4.2.0'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
@@ -34,7 +34,7 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 'jruby-9.4.1.0'
+          - 'jruby-9.4.2.0'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/release-prep
+++ b/release-prep
@@ -5,7 +5,7 @@
 # Update Gemfile.lock
 docker run -it --rm \
   -v $(pwd):/app \
-  jruby:9.4.1.0-jdk11 \
+  jruby:9.4.2.0-jdk11 \
   /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends git make netbase && cd /app && gem install bundler && bundle install --jobs 3; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'
 
 # Update Changelog

--- a/update-gemfile-lock
+++ b/update-gemfile-lock
@@ -3,5 +3,5 @@
 # The container tag should closely match what is used in `docker/Dockerfile` in vmpooler-deployment
 docker run -it --rm \
   -v $(pwd):/app \
-  jruby:9.4.1.0-jdk11 \
+  jruby:9.4.2.0-jdk11 \
   /bin/bash -c 'apt-get update -qq && apt-get install -y --no-install-recommends git make netbase && cd /app && gem install bundler && bundle install --jobs 3 && bundle update; echo "LOCK_FILE_UPDATE_EXIT_CODE=$?"'


### PR DESCRIPTION
Changelog: https://www.jruby.org/2023/03/08/jruby-9-4-2-0.html

ruby output difference:
```shell
> docker run --rm -it jruby:9.4.1.0-jdk11 bash -c 'ruby -v'
jruby 9.4.1.0 (3.1.0) 2023-02-07 237d5fa5f4 OpenJDK 64-Bit Server VM 11.0.18+10 on 11.0.18+10 +jit [x86_64-linux]

> docker run --rm -it jruby:9.4.2.0-jdk11 bash -c 'ruby -v'
jruby 9.4.2.0 (3.1.0) 2023-03-08 90d2913fda OpenJDK 64-Bit Server VM 11.0.18+10 on 11.0.18+10 +jit [x86_64-linux]
```