### PR TITLE
Migrate issue management to Jira

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
     - [Running docker-compose inside Vagrant](#running-docker-compose-inside-vagrant)
     - [URLs when using docker-compose](#urls-when-using-docker-compose)
   - [Update the Gemfile Lock](#update-the-gemfile-lock)
+  - [Submitting Issues](#submitting-issues)
   - [Releasing](#releasing)
   - [License](#license)
 
@@ -199,6 +200,10 @@ Additionally, the Redis instance can be accessed at `localhost:6379`.
 To update the `Gemfile.lock` run `./update-gemfile-lock`.
 
 Verify, and update if needed, that the docker tag in the script and GitHub action workflows matches what is used in the [vmpooler-deployment Dockerfile](https://github.com/puppetlabs/vmpooler-deployment/blob/main/docker/Dockerfile).
+
+## Submitting Issues
+
+Please file any issues or requests in Jira at <https://puppet.atlassian.net/jira/software/c/projects/POOLER/issues> where project development is tracked across all VMPooler related components.
 
 ## Releasing
 


### PR DESCRIPTION
This is to propose moving issue management to the public Jira project at https://puppet.atlassian.net/jira/software/c/projects/POOLER/issues. If this sounds good, then post merge I'll create a Jira ticket for any open GitHub issues, close the GitHub issue with reference to the Jira ticket, and disable issues on the repository.