### PR TITLE
Update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,8 @@
 # Changelog
 
-## [3.3.0](https://github.com/puppetlabs/vmpooler/tree/3.3.0) (2023-08-15)
+## [3.3.0](https://github.com/puppetlabs/vmpooler/tree/3.3.0) (2023-08-16)
 
 [Full Changelog](https://github.com/puppetlabs/vmpooler/compare/3.2.0...3.3.0)
-
-**Implemented enhancements:**
-
-- \(RE-15162\) Update Redis gem to version 5.0. [\#561](https://github.com/puppetlabs/vmpooler/pull/561) ([isaac-hammes](https://github.com/isaac-hammes))
 
 **Closed issues:**
 


### PR DESCRIPTION
I have a suspicion that the `Merge branch 'main' into update_redis` at https://github.com/puppetlabs/vmpooler/commit/113ca2dacbb8fed80a28118c28f353b80108d9c6 might be causing some issues with the changelog generator. However, the issue for that PR is still in the changelog so it's easy to see that the change happened.