### PR TITLE
(RE-15565) Add ability to use bind_as with a service account

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,6 +184,7 @@ GEM
       rspec (~> 3)
 
 PLATFORMS
+  arm64-darwin-22
   universal-java-11
   x86_64-linux
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -246,6 +246,18 @@ This can be a string providing a single DN. For multiple DNs please specify the 
 The LDAP object-type used to designate a user object.
 (optional)
 
+### LDAP\_SERVICE_ACCOUNT\_HASH
+
+A hash containing the following parameters for a service account to perform the
+initial bind. After the initial bind, then a search query is performed using the
+'base' and 'user_object', then re-binds as the returned user.
+
+- :user_dn: The full distinguished name (DN) of the service account used to bind.
+
+- :password: The password for the service account used to bind.
+
+(optional)
+
 ### SITE\_NAME
 
 The name of your deployment.

--- a/vmpooler.yaml.example
+++ b/vmpooler.yaml.example
@@ -367,6 +367,15 @@
 #   - user_object
 #     The LDAP object-type used to designate a user object.
 #
+#   - service_account_hash
+#     A hash containing the following parameters for a service account to perform the
+#     initial bind. After the initial bind, then a search query is performed using the
+#     'base' and 'user_object', then re-binds as the returned user.
+#     - :user_dn
+#     The full distinguished name (DN) of the service account used to bind.
+#     - :password
+#     The password for the service account used to bind.
+#
 # Example:
 # :auth:
 #   provider: 'ldap'
@@ -375,6 +384,23 @@
 #     port: 389
 #     base: 'ou=users,dc=company,dc=com'
 #     user_object: 'uid'
+#
+# :auth:
+#   provider: 'ldap'
+#   :ldap:
+#     host: 'ldap.example.com'
+#     port: 636
+#     service_account_hash:
+#       :user_dn: 'cn=Service Account,ou=Accounts,dc=ldap,dc=example,dc=com'
+#       :password: 'service-account-password'
+#     encryption:
+#       :method: :simple_tls
+#       :tls_options:
+#         :ssl_version: 'TLSv1_2'
+#     base:
+#       - 'ou=Accounts,dc=company,dc=com'
+#     user_object:
+#       - 'samAccountName'
 
 :auth:
   provider: 'ldap'


### PR DESCRIPTION
Fixes https://github.com/puppetlabs/vmpooler/issues/616

This retains backwards compatibility with existing ldap configurations.