### PR TITLE
Fix nil provider crash when purging unconfigured EC2 resources

### DIFF
--- a/lib/vmpooler/pool_manager.rb
+++ b/lib/vmpooler/pool_manager.rb
@@ -740,6 +740,10 @@ module Vmpooler
 
     def purge_vms_and_resources(provider_name)
       provider = $providers[provider_name.to_s]
+      unless provider
+        $logger.log('d', "[!] [purge] Skipping provider '#{provider_name}': not initialized")
+        return
+      end
       # Deprecated, will be removed in version 3
       if provider.provider_config['folder_whitelist']
         $logger.log('d', "[!] [deprecation] rename configuration 'folder_whitelist' to 'resources_allowlist' for provider #{provider_name}")


### PR DESCRIPTION
## Problem

When a provider (e.g., EC2) is listed under `:providers` in config but is not initialized in `$providers` (missing credentials, not fully configured, etc.), `purge_vms_and_resources` crashes with:

```
[!] failed while purging provider ec2 VMs and folders with an error: undefined method `provider_config' for nil:NilClass
```

This error was observed in production logs on startup when `purge_unconfigured_resources` runs for the EC2 provider.

## Fix

Add a nil guard in `purge_vms_and_resources`: if `$providers[provider_name]` is nil, log and return early instead of raising `NoMethodError`.

```ruby
unless provider
  $logger.log('d', "[!] [purge] Skipping provider '#{provider_name}': not initialized")
  return
end
```

## Testing

- Existing specs pass
- Reproduces: configure an EC2 provider in `:providers` without initializing it in `$providers`; before this fix it crashes, after this fix it logs and skips cleanly