### PR TITLE
P4DEVOPS-11504: pass redis_reconnect_attempts to API redis connection

### DIFF
--- a/bin/vmpooler
+++ b/bin/vmpooler
@@ -40,7 +40,7 @@ if torun.include?(:api)
       Vmpooler.new_redis(redis_host, redis_port, redis_password, redis_reconnect_attempts)
     end
     Vmpooler::API.execute(torun, config, redis, metrics, logger)
-  rescue => e
+  rescue StandardError => e
     logger.log('s', "[!] [api] thread crashed: #{e.message}\n#{e.backtrace.join("\n")}")
     raise
   end

--- a/bin/vmpooler
+++ b/bin/vmpooler
@@ -36,8 +36,13 @@ end
 
 if torun.include?(:api)
   api = Thread.new do
-    redis = Vmpooler.new_redis(redis_host, redis_port, redis_password)
+    redis = ConnectionPool::Wrapper.new(size: redis_connection_pool_size, timeout: redis_connection_pool_timeout) do
+      Vmpooler.new_redis(redis_host, redis_port, redis_password, redis_reconnect_attempts)
+    end
     Vmpooler::API.execute(torun, config, redis, metrics, logger)
+  rescue => e
+    logger.log('s', "[!] [api] thread crashed: #{e.message}\n#{e.backtrace.join("\n")}")
+    raise
   end
   torun_threads << api
 elsif metrics.respond_to?(:setup_prometheus_metrics)


### PR DESCRIPTION
## Problem

On startup, `vmpooler-dev` repeatedly hits `Redis::CannotConnectError` because the API thread creates its Redis connection without `redis_reconnect_attempts`:

```ruby
# Before — uses default reconnect_attempts: 10 (10 immediate retries, no delay)
Vmpooler.new_redis(redis_host, redis_port, redis_password)
```

The manager thread correctly passed the configured value, which is the exponential-backoff array `[0, 0.25, 0.5, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512]`. The API did not, so its 10 instant retries exhausted before Redis was ready.

This only surfaces in dev because dev Redis has very limited resources (13m CPU / 96Mi memory) and takes longer to start, while prod Redis is already warm on restart.

## Fix

Pass `redis_reconnect_attempts` to `Vmpooler.new_redis` in the API thread, consistent with the manager.

```ruby
# After — uses configured exponential backoff
Vmpooler.new_redis(redis_host, redis_port, redis_password, redis_reconnect_attempts)
```
